### PR TITLE
Move getParentViewForChild method to RibView

### DIFF
--- a/android/app-example/src/main/java/com/badoo/ribs/example/rib/switcher/SwitcherRouter.kt
+++ b/android/app-example/src/main/java/com/badoo/ribs/example/rib/switcher/SwitcherRouter.kt
@@ -1,9 +1,7 @@
 package com.badoo.ribs.example.rib.switcher
 
 import android.os.Parcelable
-import android.view.ViewGroup
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.Rib
 import com.badoo.ribs.core.Router
 import com.badoo.ribs.core.routing.action.AttachRibRoutingAction.Companion.attach
 import com.badoo.ribs.core.routing.action.CompositeRoutingAction.Companion.composite
@@ -11,7 +9,6 @@ import com.badoo.ribs.core.routing.action.DialogRoutingAction.Companion.showDial
 import com.badoo.ribs.core.routing.action.InvokeOnExecute.Companion.execute
 import com.badoo.ribs.core.routing.action.RoutingAction
 import com.badoo.ribs.dialog.DialogLauncher
-import com.badoo.ribs.example.rib.blocker.Blocker
 import com.badoo.ribs.example.rib.blocker.builder.BlockerBuilder
 import com.badoo.ribs.example.rib.dialog_example.builder.DialogExampleBuilder
 import com.badoo.ribs.example.rib.foo_bar.builder.FooBarBuilder
@@ -66,12 +63,5 @@ class SwitcherRouter(
             )
             is Configuration.OverlayDialog -> showDialog(dialogLauncher, dialogToTestOverlay)
             is Configuration.Blocker -> attach { blockerBuilder.build() }
-        }
-
-    override fun getParentViewForChild(child: Rib, view: SwitcherView?): ViewGroup? =
-        when (child) {
-            is Menu -> view!!.menuContainer
-            is Blocker -> view!!.blockerContainer
-            else -> view!!.contentContainer
         }
 }

--- a/android/app-example/src/main/java/com/badoo/ribs/example/rib/switcher/SwitcherView.kt
+++ b/android/app-example/src/main/java/com/badoo/ribs/example/rib/switcher/SwitcherView.kt
@@ -5,8 +5,11 @@ import android.util.AttributeSet
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.FrameLayout
+import com.badoo.ribs.core.Rib
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.example.R
+import com.badoo.ribs.example.rib.blocker.Blocker
+import com.badoo.ribs.example.rib.menu.Menu
 import com.badoo.ribs.example.rib.switcher.SwitcherView.Event
 import com.badoo.ribs.example.rib.switcher.SwitcherView.ViewModel
 import com.jakewharton.rxrelay2.PublishRelay
@@ -25,10 +28,6 @@ interface SwitcherView : RibView,
     data class ViewModel(
         val i: Int = 0
     )
-
-    val menuContainer: ViewGroup
-    val contentContainer: ViewGroup
-    val blockerContainer: ViewGroup
 }
 
 
@@ -44,9 +43,9 @@ class SwitcherViewImpl private constructor(
     ) : this(context, attrs, defStyle, PublishRelay.create<Event>())
 
     override val androidView = this
-    override val menuContainer: ViewGroup by lazy { findViewById<ViewGroup>(R.id.menu_container) }
-    override val contentContainer: ViewGroup by lazy { findViewById<ViewGroup>(R.id.content_container) }
-    override val blockerContainer: ViewGroup by lazy { findViewById<ViewGroup>(R.id.blocker_container) }
+    private val menuContainer: ViewGroup by lazy { findViewById<ViewGroup>(R.id.menu_container) }
+    private val contentContainer: ViewGroup by lazy { findViewById<ViewGroup>(R.id.content_container) }
+    private val blockerContainer: ViewGroup by lazy { findViewById<ViewGroup>(R.id.blocker_container) }
     private val showOverlayDialog: Button by lazy { findViewById<Button>(R.id.show_overlay_dialog) }
     private val showBlocker: Button by lazy { findViewById<Button>(R.id.show_blocker) }
 
@@ -58,4 +57,11 @@ class SwitcherViewImpl private constructor(
 
     override fun accept(vm: ViewModel) {
     }
+
+    override fun getParentViewForChild(child: Rib): ViewGroup? =
+        when (child) {
+            is Menu -> menuContainer
+            is Blocker -> blockerContainer
+            else -> contentContainer
+        }
 }

--- a/android/app-example/src/test/java/com/badoo/ribs/example/rib/test/MainScreenTest.kt
+++ b/android/app-example/src/test/java/com/badoo/ribs/example/rib/test/MainScreenTest.kt
@@ -122,9 +122,5 @@ class MainScreenTest {
 
     class TestHelloWorldView : TestView<HelloWorldView.ViewModel, HelloWorldView.Event>(), HelloWorldView
 
-    class TestSwitcherView : TestView<SwitcherView.ViewModel, SwitcherView.Event>(), SwitcherView {
-        override val menuContainer: ViewGroup = mock()
-        override val blockerContainer: ViewGroup = mock()
-        override val contentContainer: ViewGroup = mock()
-    }
+    class TestSwitcherView : TestView<SwitcherView.ViewModel, SwitcherView.Event>(), SwitcherView
 }

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
@@ -97,7 +97,7 @@ open class Node<V : RibView>(
         if (isViewAttached) {
             child.attachToView(
                 // parentViewGroup is guaranteed to be non-null if and only if view is attached
-                router.getParentViewForChild(child.identifier, view) ?: parentViewGroup!!
+                view?.getParentViewForChild(child.identifier) ?: parentViewGroup!!
             )
         }
     }

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Router.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Router.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.core
 
 import android.os.Bundle
 import android.os.Parcelable
-import android.view.ViewGroup
 import com.badoo.mvicore.android.AndroidTimeCapsule
 import com.badoo.mvicore.binder.Binder
 import com.badoo.ribs.core.routing.NodeConnector
@@ -59,14 +58,6 @@ abstract class Router<C : Parcelable, V : RibView>(
     }
 
     abstract fun resolveConfiguration(configuration: C): RoutingAction<V>
-
-    /**
-     * @param view is null only in the case when the supplied ViewFactory in the Node is null,
-     *              and as such, it should be referenced by view!! when overriding this method
-     *              to catch any problems instead of silently returning null
-     */
-    open fun getParentViewForChild(child: Rib, view: V?): ViewGroup? =
-        view?.androidView
 
     fun onSaveInstanceState(outState: Bundle) {
         backStackManager.accept(SaveInstanceState())

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/view/RibView.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/view/RibView.kt
@@ -1,8 +1,12 @@
 package com.badoo.ribs.core.view
 
 import android.view.ViewGroup
+import com.badoo.ribs.core.Rib
 
 interface RibView {
 
     val androidView: ViewGroup
+
+    fun getParentViewForChild(child: Rib): ViewGroup? =
+        androidView
 }

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
@@ -359,7 +359,7 @@ class NodeTest {
 
     @Test
     fun `attachChildView() results in children added to parentViewGroup given Router does not define something else `() {
-        whenever(router.getParentViewForChild(any(), anyOrNull())).thenReturn(null)
+        whenever(view.getParentViewForChild(any())).thenReturn(null)
         val mocks = createAndAttachChildMocks(3)
         node.attachToView(parentViewGroup)
         mocks.forEach {
@@ -375,9 +375,9 @@ class NodeTest {
         val n3 = object : RandomOtherNode3 {}
         val mocks = createAndAttachChildMocks(3, mutableListOf(n1, n2, n3))
 
-        whenever(router.getParentViewForChild(n1, view)).thenReturn(someViewGroup1)
-        whenever(router.getParentViewForChild(n2, view)).thenReturn(someViewGroup2)
-        whenever(router.getParentViewForChild(n3, view)).thenReturn(someViewGroup3)
+        whenever(view.getParentViewForChild(n1)).thenReturn(someViewGroup1)
+        whenever(view.getParentViewForChild(n2)).thenReturn(someViewGroup2)
+        whenever(view.getParentViewForChild(n3)).thenReturn(someViewGroup3)
 
         node.attachToView(parentViewGroup)
 

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestView.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestView.kt
@@ -1,10 +1,14 @@
 package com.badoo.ribs.core.helper
 
 import android.view.ViewGroup
+import com.badoo.ribs.core.Rib
 import com.badoo.ribs.core.view.RibView
 import com.nhaarman.mockitokotlin2.mock
 
 class TestView : RibView {
 
     override val androidView: ViewGroup = mock()
+
+    override fun getParentViewForChild(child: Rib): ViewGroup? =
+        androidView
 }


### PR DESCRIPTION
`getParentViewForChild` method was in `Router` for historical reasons (when view attaching was done manually in `Router`), but conceptually it's in a better place in `RibView`.

Benefits:
- Actually responsibility of `View`, not `Router`
- Don't need to care for `View` null case in `Router`
- Don't need to expose `ViewGroup` fields in specific `View` interface, they can remain an implementation detail + we can avoid having to implement it in all other `View` implementations