### PR TITLE
Lifecycle improvements

### DIFF
--- a/android/app-example/src/test/java/com/badoo/ribs/example/rib/switcher/SwitcherRouterTest.kt
+++ b/android/app-example/src/test/java/com/badoo/ribs/example/rib/switcher/SwitcherRouterTest.kt
@@ -1,20 +1,23 @@
 package com.badoo.ribs.example.rib.switcher
 
-import com.badoo.ribs.core.Builder
-import com.badoo.ribs.core.Node
 import com.badoo.ribs.dialog.DialogLauncher
+import com.badoo.ribs.example.rib.blocker.BlockerView
 import com.badoo.ribs.example.rib.blocker.builder.BlockerBuilder
+import com.badoo.ribs.example.rib.dialog_example.DialogExampleView
 import com.badoo.ribs.example.rib.dialog_example.builder.DialogExampleBuilder
+import com.badoo.ribs.example.rib.foo_bar.FooBarView
 import com.badoo.ribs.example.rib.foo_bar.builder.FooBarBuilder
+import com.badoo.ribs.example.rib.hello_world.HelloWorldView
 import com.badoo.ribs.example.rib.hello_world.builder.HelloWorldBuilder
 import com.badoo.ribs.example.rib.menu.Menu
-import com.badoo.ribs.example.rib.menu.Menu.MenuItem.HelloWorld
-import com.badoo.ribs.example.rib.menu.Menu.MenuItem.FooBar
 import com.badoo.ribs.example.rib.menu.Menu.MenuItem.Dialogs
+import com.badoo.ribs.example.rib.menu.Menu.MenuItem.FooBar
+import com.badoo.ribs.example.rib.menu.Menu.MenuItem.HelloWorld
+import com.badoo.ribs.example.rib.menu.MenuView
 import com.badoo.ribs.example.rib.menu.builder.MenuBuilder
+import com.badoo.ribs.example.rib.switcher.SwitcherRouter.Configuration.Content.Blocker
 import com.badoo.ribs.example.rib.switcher.SwitcherRouter.Configuration.Content.Foo
 import com.badoo.ribs.example.rib.switcher.SwitcherRouter.Configuration.Content.Hello
-import com.badoo.ribs.example.rib.switcher.SwitcherRouter.Configuration.Content.Blocker
 import com.badoo.ribs.example.rib.switcher.SwitcherRouter.Configuration.Overlay.Dialog
 import com.badoo.ribs.example.rib.switcher.dialog.DialogToTestOverlay
 import com.badoo.ribs.example.rib.util.TestNode
@@ -33,20 +36,20 @@ import org.junit.Test
  */
 class SwitcherRouterTest {
 
-    private val fooBarBuilder = createBuilder<FooBarBuilder> { build() }
-    private val fooBarNode = fooBarBuilder.build()
+    private val fooBarNode = TestNode<FooBarView>()
+    private val fooBarBuilder = mock<FooBarBuilder> { on { build() } doReturn fooBarNode }
 
-    private val helloWorldBuilder = createBuilder<HelloWorldBuilder> { build() }
-    private val helloWorldNode = helloWorldBuilder.build()
+    private val helloWorldNode = TestNode<HelloWorldView>()
+    private val helloWorldBuilder = mock<HelloWorldBuilder> { on { build() } doReturn helloWorldNode }
 
-    private val dialogExampleBuilder = createBuilder<DialogExampleBuilder> { build() }
-    private val dialogExampleNode = dialogExampleBuilder.build()
+    private val dialogExampleNode = TestNode<DialogExampleView>()
+    private val dialogExampleBuilder = mock<DialogExampleBuilder> { on { build() } doReturn dialogExampleNode }
 
-    private val blockerBuilder = createBuilder<BlockerBuilder> { build() }
-    private val blockerNode = blockerBuilder.build()
+    private val blockerNode = TestNode<BlockerView>()
+    private val blockerBuilder = mock<BlockerBuilder> { on { build() } doReturn blockerNode }
 
-    private val menuBuilder = createBuilder<MenuBuilder> { build() }
-    private val menuNode = menuBuilder.build()
+    private val menuNode = TestNode<MenuView>()
+    private val menuBuilder = mock<MenuBuilder> { on { build() } doReturn menuNode }
 
     private val dialogLauncher: DialogLauncher = mock()
     private val dialogToTestOverlay: DialogToTestOverlay = mock()
@@ -142,9 +145,4 @@ class SwitcherRouterTest {
 
         assertThat(rootNode.getChildren()).containsExactlyInAnyOrder(menuNode, blockerNode)
     }
-
-    private inline fun <reified B : Builder<*>> createBuilder(noinline buildCall: B.() -> Node<*>) =
-        mock<B> {
-            on(buildCall) doReturn mock(name = "Node mock for ${B::class.java.simpleName}")
-        }
 }

--- a/android/app-example/src/test/java/com/badoo/ribs/example/rib/util/TestNode.kt
+++ b/android/app-example/src/test/java/com/badoo/ribs/example/rib/util/TestNode.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.core.view.ViewFactory
 import com.nhaarman.mockitokotlin2.mock
 
 class TestNode<V : RibView>(
-    router: Router<*, *, *, *, V>,
+    router: Router<*, *, *, *, V> = mock(),
     identifier: Rib = object : Rib {},
     viewFactory: ViewFactory<V> = mock(),
     interactor: Interactor<*, *, *, V> = mock()

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/BaseNodesTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/BaseNodesTest.kt
@@ -22,7 +22,7 @@ abstract class BaseNodesTest {
         val pushConfiguration2: TestRootRouter.Configuration? = null
     )
 
-    protected fun test(setup: When, expectedState: ExpectedState, testBlock: (TestRootRouter) -> Unit) {
+    protected fun test(setup: When, expectedState: ExpectedState, testBlock: (TestRootRouter, TestNode<*>) -> Unit) {
         val rootProvider = TestRoot.Provider(
             initialConfiguration = setup.initialConfiguration,
             permanentParts = setup.permanentParts
@@ -32,7 +32,7 @@ abstract class BaseNodesTest {
 
         val router: TestRootRouter = rootProvider.rootNode?.getRouter() as TestRootRouter
 
-        testBlock.invoke(router)
+        testBlock.invoke(router, rootProvider.rootNode!!)
 
         rootProvider.makeAssertions(expectedState)
     }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/BaseNodesTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/BaseNodesTest.kt
@@ -56,7 +56,7 @@ abstract class BaseNodesTest {
     private fun TestNode<*>.toNodeState() =
         NodeState(
             attached = isAttached,
-            viewAttached = isViewAttached,
+            viewAttached = isAttachedToView,
             ribLifeCycleState = ribLifecycleRegistry.currentState,
             viewLifeCycleState = viewLifecycleRegistry.currentState
         )

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/BaseNodesTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/BaseNodesTest.kt
@@ -56,6 +56,8 @@ abstract class BaseNodesTest {
     private fun TestNode<*>.toNodeState() =
         NodeState(
             attached = isAttached,
-            viewAttached = isViewAttached
+            viewAttached = isViewAttached,
+            ribLifeCycleState = ribLifecycleRegistry.currentState,
+            viewLifeCycleState = viewLifecycleRegistry.currentState
         )
 }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/InitialNodesStateTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/InitialNodesStateTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 class InitialNodesStateTest : BaseNodesTest() {
 
     private fun whenRootIsCreated(setup: When, expectedState: ExpectedState) {
-        test(setup, expectedState) {
+        test(setup, expectedState) { _, _ ->
             // no special operations here, just test initial
         }
     }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushOneTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushOneTest.kt
@@ -1,8 +1,8 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushOneTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushOneTest.kt
@@ -13,9 +13,9 @@ import org.junit.Test
 class PushOneTest : BaseNodesTest() {
 
     private fun pushOneConfiguration(setup: When, expectedState: ExpectedState) {
-        test(setup, expectedState) {
+        test(setup, expectedState) { router, _ ->
             runOnMainSync {
-                it.pushIt(setup.pushConfiguration1!!)
+                router.pushIt(setup.pushConfiguration1!!)
             }
         }
     }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushOneTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushOneTest.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent
 import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
-class PushOneConfigurationNodesStateTest : BaseNodesTest() {
+class PushOneTest : BaseNodesTest() {
 
     private fun pushOneConfiguration(setup: When, expectedState: ExpectedState) {
         test(setup, expectedState) {

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneDefaultTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneDefaultTest.kt
@@ -1,18 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOneDefaultTest : PushTwoPopOneTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneDefaultTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneDefaultTest.kt
@@ -1,0 +1,28 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOneDefaultTest : PushTwoPopOneTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, _ ->
+            runOnMainSync {
+                router.pushIt(setup.pushConfiguration1!!)
+                router.pushIt(setup.pushConfiguration2!!)
+                router.popBackStack()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseAfterPopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseAfterPopTest.kt
@@ -1,19 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOnePauseAfterPopTest : PushTwoPopOnePauseTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseAfterPopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseAfterPopTest.kt
@@ -1,0 +1,30 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOnePauseAfterPopTest : PushTwoPopOnePauseTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                router.pushIt(setup.pushConfiguration1!!)
+                router.pushIt(setup.pushConfiguration2!!)
+                rootNode.onPause()
+                router.popBackStack()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseAfterPopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseAfterPopTest.kt
@@ -10,8 +10,8 @@ class PushTwoPopOnePauseAfterPopTest : PushTwoPopOnePauseTest() {
             runOnMainSync {
                 router.pushIt(setup.pushConfiguration1!!)
                 router.pushIt(setup.pushConfiguration2!!)
-                rootNode.onPause()
                 router.popBackStack()
+                rootNode.onPause()
             }
         }
     }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePopTest.kt
@@ -9,8 +9,8 @@ class PushTwoPopOnePauseBeforePopTest : PushTwoPopOnePauseTest() {
         test(setup, expectedState) { router, rootNode ->
             runOnMainSync {
                 router.pushIt(setup.pushConfiguration1!!)
-                rootNode.onPause()
                 router.pushIt(setup.pushConfiguration2!!)
+                rootNode.onPause()
                 router.popBackStack()
             }
         }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePopTest.kt
@@ -1,19 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOnePauseBeforePopTest : PushTwoPopOnePauseTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePopTest.kt
@@ -1,0 +1,30 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOnePauseBeforePopTest : PushTwoPopOnePauseTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                router.pushIt(setup.pushConfiguration1!!)
+                rootNode.onPause()
+                router.pushIt(setup.pushConfiguration2!!)
+                router.popBackStack()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePushTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePushTest.kt
@@ -1,19 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOnePauseBeforePushTest : PushTwoPopOnePauseTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePushTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePushTest.kt
@@ -1,0 +1,30 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOnePauseBeforePushTest : PushTwoPopOnePauseTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                router.pushIt(setup.pushConfiguration1!!)
+                router.pushIt(setup.pushConfiguration2!!)
+                router.popBackStack()
+                rootNode.onPause()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePushTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBeforePushTest.kt
@@ -8,10 +8,10 @@ class PushTwoPopOnePauseBeforePushTest : PushTwoPopOnePauseTest() {
     override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
         test(setup, expectedState) { router, rootNode ->
             runOnMainSync {
+                rootNode.onPause()
                 router.pushIt(setup.pushConfiguration1!!)
                 router.pushIt(setup.pushConfiguration2!!)
                 router.popBackStack()
-                rootNode.onPause()
             }
         }
     }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBetweenPushesTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBetweenPushesTest.kt
@@ -1,0 +1,30 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOnePauseBetweenPushesTest : PushTwoPopOnePauseTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                rootNode.onPause()
+                router.pushIt(setup.pushConfiguration1!!)
+                router.pushIt(setup.pushConfiguration2!!)
+                router.popBackStack()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBetweenPushesTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBetweenPushesTest.kt
@@ -1,19 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOnePauseBetweenPushesTest : PushTwoPopOnePauseTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBetweenPushesTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseBetweenPushesTest.kt
@@ -8,8 +8,8 @@ class PushTwoPopOnePauseBetweenPushesTest : PushTwoPopOnePauseTest() {
     override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
         test(setup, expectedState) { router, rootNode ->
             runOnMainSync {
-                rootNode.onPause()
                 router.pushIt(setup.pushConfiguration1!!)
+                rootNode.onPause()
                 router.pushIt(setup.pushConfiguration2!!)
                 router.popBackStack()
             }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseTest.kt
@@ -15,18 +15,9 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent
 import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
-class PushTwoPopOnePauseTest : BaseNodesTest() {
+abstract class PushTwoPopOnePauseTest : BaseNodesTest() {
 
-    private fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
-        test(setup, expectedState) { router, rootNode ->
-            runOnMainSync {
-                router.pushIt(setup.pushConfiguration1!!)
-                router.pushIt(setup.pushConfiguration2!!)
-                router.popBackStack()
-                rootNode.onPause()
-            }
-        }
-    }
+    protected abstract fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState)
 
     @Test
     fun noPermanent_singleInitial_pushContent_pushContent_pop() {

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseTest.kt
@@ -26,9 +26,9 @@ abstract class PushTwoPopOnePauseTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3
             ),
             ExpectedState(
-                node1 = VIEW_DETACHED, // Next content should cause view detach on first
-                node2 = ON_SCREEN_PAUSED,     // This should be restored after pop
-                node3 = DETACHED       // This should be popped
+                node1 = VIEW_DETACHED,      // Next content should cause view detach on first
+                node2 = ON_SCREEN_PAUSED,   // This should be restored after pop
+                node3 = DETACHED            // This should be popped
             )
         )
     }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseTest.kt
@@ -2,9 +2,8 @@ package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
@@ -12,7 +11,6 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.A
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
-import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
 abstract class PushTwoPopOnePauseTest : BaseNodesTest() {

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOnePauseTest.kt
@@ -4,6 +4,7 @@ import com.badoo.ribs.android.lifecycle.helper.ExpectedState
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
@@ -14,14 +15,15 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent
 import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
-class PushTwoPopOneTest : BaseNodesTest() {
+class PushTwoPopOnePauseTest : BaseNodesTest() {
 
     private fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
-        test(setup, expectedState) { router, _ ->
+        test(setup, expectedState) { router, rootNode ->
             runOnMainSync {
                 router.pushIt(setup.pushConfiguration1!!)
                 router.pushIt(setup.pushConfiguration2!!)
                 router.popBackStack()
+                rootNode.onPause()
             }
         }
     }
@@ -36,7 +38,7 @@ class PushTwoPopOneTest : BaseNodesTest() {
             ),
             ExpectedState(
                 node1 = VIEW_DETACHED, // Next content should cause view detach on first
-                node2 = ON_SCREEN,     // This should be restored after pop
+                node2 = ON_SCREEN_PAUSED,     // This should be restored after pop
                 node3 = DETACHED       // This should be popped
             )
         )
@@ -51,9 +53,9 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3AsOverlay
             ),
             ExpectedState(
-                node1 = VIEW_DETACHED, // Next content should cause view detach on first
-                node2 = ON_SCREEN,     // This should be restored after pop
-                node3 = DETACHED       // This should be popped
+                node1 = VIEW_DETACHED,      // Next content should cause view detach on first
+                node2 = ON_SCREEN_PAUSED,   // This should be restored after pop
+                node3 = DETACHED            // This should be popped
             )
         )
     }
@@ -67,9 +69,9 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3AsOverlay
             ),
             ExpectedState(
-                node1 = ON_SCREEN, // This should be restored after pop (next one is overlay)
-                node2 = ON_SCREEN, // This should be restored after pop
-                node3 = DETACHED   // This should be popped
+                node1 = ON_SCREEN_PAUSED, // This should be restored after pop (next one is overlay)
+                node2 = ON_SCREEN_PAUSED, // This should be restored after pop
+                node3 = DETACHED          // This should be popped
             )
         )
     }
@@ -83,9 +85,9 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3
             ),
             ExpectedState(
-                node1 = ON_SCREEN, // This should be restored after pop (next one is overlay)
-                node2 = ON_SCREEN, // This should be restored after pop
-                node3 = DETACHED   // This should be popped
+                node1 = ON_SCREEN_PAUSED, // This should be restored after pop (next one is overlay)
+                node2 = ON_SCREEN_PAUSED, // This should be restored after pop
+                node3 = DETACHED          // This should be popped
             )
         )
     }
@@ -100,11 +102,11 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3
             ),
             ExpectedState(
-                permanentNode1 = ON_SCREEN, // This should always be on screen
-                permanentNode2 = ON_SCREEN, // This should always be on screen
-                node1 = VIEW_DETACHED,      // Next content should cause view detach on first
-                node2 = ON_SCREEN,          // This should be restored after pop
-                node3 = DETACHED            // This should be popped
+                permanentNode1 = ON_SCREEN_PAUSED, // This should always be on screen
+                permanentNode2 = ON_SCREEN_PAUSED, // This should always be on screen
+                node1 = VIEW_DETACHED,             // Next content should cause view detach on first
+                node2 = ON_SCREEN_PAUSED,          // This should be restored after pop
+                node3 = DETACHED                   // This should be popped
             )
         )
     }
@@ -119,11 +121,11 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3AsOverlay
             ),
             ExpectedState(
-                permanentNode1 = ON_SCREEN, // This should always be on screen
-                permanentNode2 = ON_SCREEN, // This should always be on screen
-                node1 = VIEW_DETACHED,      // Second content should cause view detach on first
-                node2 = ON_SCREEN,          // This should be restored after pop
-                node3 = DETACHED            // This should be popped
+                permanentNode1 = ON_SCREEN_PAUSED, // This should always be on screen
+                permanentNode2 = ON_SCREEN_PAUSED, // This should always be on screen
+                node1 = VIEW_DETACHED,             // Second content should cause view detach on first
+                node2 = ON_SCREEN_PAUSED,          // This should be restored after pop
+                node3 = DETACHED                   // This should be popped
             )
         )
     }
@@ -138,11 +140,11 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3AsOverlay
             ),
             ExpectedState(
-                permanentNode1 = ON_SCREEN, // This should always be on screen
-                permanentNode2 = ON_SCREEN, // This should always be on screen
-                node1 = ON_SCREEN,          // This should be restored after pop (next one is overlay)
-                node2 = ON_SCREEN,          // This should be restored after pop
-                node3 = DETACHED            // This should be popped
+                permanentNode1 = ON_SCREEN_PAUSED, // This should always be on screen
+                permanentNode2 = ON_SCREEN_PAUSED, // This should always be on screen
+                node1 = ON_SCREEN_PAUSED,          // This should be restored after pop (next one is overlay)
+                node2 = ON_SCREEN_PAUSED,          // This should be restored after pop
+                node3 = DETACHED                   // This should be popped
             )
         )
     }
@@ -157,11 +159,11 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3
             ),
             ExpectedState(
-                permanentNode1 = ON_SCREEN, // This should always be on screen
-                permanentNode2 = ON_SCREEN, // This should always be on screen
-                node1 = ON_SCREEN,          // This should be restored after pop (next one is overlay)
-                node2 = ON_SCREEN,          // This should be restored after pop
-                node3 = DETACHED            // This should be popped
+                permanentNode1 = ON_SCREEN_PAUSED, // This should always be on screen
+                permanentNode2 = ON_SCREEN_PAUSED, // This should always be on screen
+                node1 = ON_SCREEN_PAUSED,          // This should be restored after pop (next one is overlay)
+                node2 = ON_SCREEN_PAUSED,          // This should be restored after pop
+                node3 = DETACHED                   // This should be popped
             )
         )
     }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopAfterPopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopAfterPopTest.kt
@@ -1,18 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_STOPPED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOneStopAfterPopTest : PushTwoPopOneStopTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopAfterPopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopAfterPopTest.kt
@@ -1,0 +1,29 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_STOPPED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOneStopAfterPopTest : PushTwoPopOneStopTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                router.pushIt(setup.pushConfiguration1!!)
+                router.pushIt(setup.pushConfiguration2!!)
+                router.popBackStack()
+                rootNode.onStop()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBeforePopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBeforePopTest.kt
@@ -1,18 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_STOPPED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOneStopBeforePopTest : PushTwoPopOneStopTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBeforePopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBeforePopTest.kt
@@ -1,0 +1,29 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_STOPPED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOneStopBeforePopTest : PushTwoPopOneStopTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                router.pushIt(setup.pushConfiguration1!!)
+                router.pushIt(setup.pushConfiguration2!!)
+                rootNode.onStop()
+                router.popBackStack()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBeforePushTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBeforePushTest.kt
@@ -1,0 +1,29 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_STOPPED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOneStopBeforePushTest : PushTwoPopOneStopTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                rootNode.onStop()
+                router.pushIt(setup.pushConfiguration1!!)
+                router.pushIt(setup.pushConfiguration2!!)
+                router.popBackStack()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBeforePushTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBeforePushTest.kt
@@ -1,18 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_STOPPED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOneStopBeforePushTest : PushTwoPopOneStopTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBetweenPushesTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBetweenPushesTest.kt
@@ -1,18 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_STOPPED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOneStopBetweenPushesTest : PushTwoPopOneStopTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBetweenPushesTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopBetweenPushesTest.kt
@@ -1,0 +1,29 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_STOPPED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOneStopBetweenPushesTest : PushTwoPopOneStopTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                router.pushIt(setup.pushConfiguration1!!)
+                rootNode.onStop()
+                router.pushIt(setup.pushConfiguration2!!)
+                router.popBackStack()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopStartResumeTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopStartResumeTest.kt
@@ -1,19 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOneStopStartResumeTest : PushTwoPopOneTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopStartResumeTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopStartResumeTest.kt
@@ -1,0 +1,32 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOneStopStartResumeTest : PushTwoPopOneTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                rootNode.onStop()
+                router.pushIt(setup.pushConfiguration1!!)
+                rootNode.onStart()
+                router.pushIt(setup.pushConfiguration2!!)
+                rootNode.onResume()
+                router.popBackStack()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopStartTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopStartTest.kt
@@ -1,0 +1,31 @@
+package com.badoo.ribs.android.lifecycle
+
+import com.badoo.ribs.android.lifecycle.helper.ExpectedState
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
+import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
+import com.badoo.ribs.test.util.runOnMainSync
+import org.junit.Test
+
+class PushTwoPopOneStopStartTest : PushTwoPopOnePauseTest() {
+
+    override fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
+        test(setup, expectedState) { router, rootNode ->
+            runOnMainSync {
+                rootNode.onStop()
+                router.pushIt(setup.pushConfiguration1!!)
+                rootNode.onStart()
+                router.pushIt(setup.pushConfiguration2!!)
+                router.popBackStack()
+            }
+        }
+    }
+}

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopStartTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopStartTest.kt
@@ -1,19 +1,7 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_PAUSED
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode2AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
-import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
 import com.badoo.ribs.test.util.runOnMainSync
-import org.junit.Test
 
 class PushTwoPopOneStopStartTest : PushTwoPopOnePauseTest() {
 

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopTest.kt
@@ -2,8 +2,8 @@ package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN_STOPPED
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
@@ -14,14 +14,15 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent
 import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
-class PushTwoPopOneTest : BaseNodesTest() {
+class PushTwoPopOneStopTest : BaseNodesTest() {
 
     private fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
-        test(setup, expectedState) { router, _ ->
+        test(setup, expectedState) { router, rootNode ->
             runOnMainSync {
                 router.pushIt(setup.pushConfiguration1!!)
                 router.pushIt(setup.pushConfiguration2!!)
                 router.popBackStack()
+                rootNode.onStop()
             }
         }
     }
@@ -35,9 +36,9 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3
             ),
             ExpectedState(
-                node1 = VIEW_DETACHED, // Next content should cause view detach on first
-                node2 = ON_SCREEN,     // This should be restored after pop
-                node3 = DETACHED       // This should be popped
+                node1 = VIEW_DETACHED,      // Next content should cause view detach on first
+                node2 = ON_SCREEN_STOPPED,  // This should be restored after pop
+                node3 = DETACHED            // This should be popped
             )
         )
     }
@@ -51,9 +52,9 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3AsOverlay
             ),
             ExpectedState(
-                node1 = VIEW_DETACHED, // Next content should cause view detach on first
-                node2 = ON_SCREEN,     // This should be restored after pop
-                node3 = DETACHED       // This should be popped
+                node1 = VIEW_DETACHED,      // Next content should cause view detach on first
+                node2 = ON_SCREEN_STOPPED,  // This should be restored after pop
+                node3 = DETACHED            // This should be popped
             )
         )
     }
@@ -67,9 +68,9 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3AsOverlay
             ),
             ExpectedState(
-                node1 = ON_SCREEN, // This should be restored after pop (next one is overlay)
-                node2 = ON_SCREEN, // This should be restored after pop
-                node3 = DETACHED   // This should be popped
+                node1 = ON_SCREEN_STOPPED, // This should be restored after pop (next one is overlay)
+                node2 = ON_SCREEN_STOPPED, // This should be restored after pop
+                node3 = DETACHED           // This should be popped
             )
         )
     }
@@ -83,9 +84,9 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3
             ),
             ExpectedState(
-                node1 = ON_SCREEN, // This should be restored after pop (next one is overlay)
-                node2 = ON_SCREEN, // This should be restored after pop
-                node3 = DETACHED   // This should be popped
+                node1 = ON_SCREEN_STOPPED, // This should be restored after pop (next one is overlay)
+                node2 = ON_SCREEN_STOPPED, // This should be restored after pop
+                node3 = DETACHED           // This should be popped
             )
         )
     }
@@ -100,11 +101,11 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3
             ),
             ExpectedState(
-                permanentNode1 = ON_SCREEN, // This should always be on screen
-                permanentNode2 = ON_SCREEN, // This should always be on screen
-                node1 = VIEW_DETACHED,      // Next content should cause view detach on first
-                node2 = ON_SCREEN,          // This should be restored after pop
-                node3 = DETACHED            // This should be popped
+                permanentNode1 = ON_SCREEN_STOPPED, // This should always be on screen
+                permanentNode2 = ON_SCREEN_STOPPED, // This should always be on screen
+                node1 = VIEW_DETACHED,              // Next content should cause view detach on first
+                node2 = ON_SCREEN_STOPPED,          // This should be restored after pop
+                node3 = DETACHED                    // This should be popped
             )
         )
     }
@@ -119,11 +120,11 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3AsOverlay
             ),
             ExpectedState(
-                permanentNode1 = ON_SCREEN, // This should always be on screen
-                permanentNode2 = ON_SCREEN, // This should always be on screen
-                node1 = VIEW_DETACHED,      // Second content should cause view detach on first
-                node2 = ON_SCREEN,          // This should be restored after pop
-                node3 = DETACHED            // This should be popped
+                permanentNode1 = ON_SCREEN_STOPPED, // This should always be on screen
+                permanentNode2 = ON_SCREEN_STOPPED, // This should always be on screen
+                node1 = VIEW_DETACHED,              // Second content should cause view detach on first
+                node2 = ON_SCREEN_STOPPED,          // This should be restored after pop
+                node3 = DETACHED                    // This should be popped
             )
         )
     }
@@ -138,11 +139,11 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3AsOverlay
             ),
             ExpectedState(
-                permanentNode1 = ON_SCREEN, // This should always be on screen
-                permanentNode2 = ON_SCREEN, // This should always be on screen
-                node1 = ON_SCREEN,          // This should be restored after pop (next one is overlay)
-                node2 = ON_SCREEN,          // This should be restored after pop
-                node3 = DETACHED            // This should be popped
+                permanentNode1 = ON_SCREEN_STOPPED, // This should always be on screen
+                permanentNode2 = ON_SCREEN_STOPPED, // This should always be on screen
+                node1 = ON_SCREEN_STOPPED,          // This should be restored after pop (next one is overlay)
+                node2 = ON_SCREEN_STOPPED,          // This should be restored after pop
+                node3 = DETACHED                    // This should be popped
             )
         )
     }
@@ -157,11 +158,11 @@ class PushTwoPopOneTest : BaseNodesTest() {
                 pushConfiguration2 = AttachNode3
             ),
             ExpectedState(
-                permanentNode1 = ON_SCREEN, // This should always be on screen
-                permanentNode2 = ON_SCREEN, // This should always be on screen
-                node1 = ON_SCREEN,          // This should be restored after pop (next one is overlay)
-                node2 = ON_SCREEN,          // This should be restored after pop
-                node3 = DETACHED            // This should be popped
+                permanentNode1 = ON_SCREEN_STOPPED, // This should always be on screen
+                permanentNode2 = ON_SCREEN_STOPPED, // This should always be on screen
+                node1 = ON_SCREEN_STOPPED,          // This should be restored after pop (next one is overlay)
+                node2 = ON_SCREEN_STOPPED,          // This should be restored after pop
+                node3 = DETACHED                    // This should be popped
             )
         )
     }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneStopTest.kt
@@ -11,21 +11,11 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.A
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
-import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
-class PushTwoPopOneStopTest : BaseNodesTest() {
+abstract class PushTwoPopOneStopTest : BaseNodesTest() {
 
-    private fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
-        test(setup, expectedState) { router, rootNode ->
-            runOnMainSync {
-                router.pushIt(setup.pushConfiguration1!!)
-                router.pushIt(setup.pushConfiguration2!!)
-                router.popBackStack()
-                rootNode.onStop()
-            }
-        }
-    }
+    protected abstract fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState)
 
     @Test
     fun noPermanent_singleInitial_pushContent_pushContent_pop() {

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneTest.kt
@@ -14,17 +14,9 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent
 import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
-class PushTwoPopOneTest : BaseNodesTest() {
+abstract class PushTwoPopOneTest : BaseNodesTest() {
 
-    private fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
-        test(setup, expectedState) { router, _ ->
-            runOnMainSync {
-                router.pushIt(setup.pushConfiguration1!!)
-                router.pushIt(setup.pushConfiguration2!!)
-                router.popBackStack()
-            }
-        }
-    }
+    protected abstract fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState)
 
     @Test
     fun noPermanent_singleInitial_pushContent_pushContent_pop() {

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneTest.kt
@@ -14,7 +14,7 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent
 import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
-class PushTwoConfigurationsAndPopNodesStateTest : BaseNodesTest() {
+class PushTwoPopOneTest : BaseNodesTest() {
 
     private fun pushTwoConfigurationAndPop(setup: When, expectedState: ExpectedState) {
         test(setup, expectedState) { router ->

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoPopOneTest.kt
@@ -2,8 +2,8 @@ package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.DETACHED
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3
@@ -11,7 +11,6 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.A
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Overlay.AttachNode3AsOverlay
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent1
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent.Permanent2
-import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
 abstract class PushTwoPopOneTest : BaseNodesTest() {

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoTest.kt
@@ -13,7 +13,7 @@ import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Permanent
 import com.badoo.ribs.test.util.runOnMainSync
 import org.junit.Test
 
-class PushTwoConfigurationsNodesStateTest  : BaseNodesTest() {
+class PushTwoTest  : BaseNodesTest() {
 
     private fun pushTwoConfigurations(setup: When, expectedState: ExpectedState) {
         test(setup, expectedState) { router ->

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoTest.kt
@@ -16,7 +16,7 @@ import org.junit.Test
 class PushTwoTest  : BaseNodesTest() {
 
     private fun pushTwoConfigurations(setup: When, expectedState: ExpectedState) {
-        test(setup, expectedState) { router ->
+        test(setup, expectedState) { router, _ ->
             runOnMainSync {
                 router.pushIt(setup.pushConfiguration1!!)
                 router.pushIt(setup.pushConfiguration2!!)

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/PushTwoTest.kt
@@ -1,8 +1,8 @@
 package com.badoo.ribs.android.lifecycle
 
 import com.badoo.ribs.android.lifecycle.helper.ExpectedState
-import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
 import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.ON_SCREEN
+import com.badoo.ribs.android.lifecycle.helper.NodeState.Companion.VIEW_DETACHED
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode1
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode2
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.Content.AttachNode3

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/RestartActivityNodesStateTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/RestartActivityNodesStateTest.kt
@@ -18,7 +18,7 @@ import org.junit.Test
 class RestartActivityNodesStateTest : BaseNodesTest() {
 
     private fun testPushTwoConfigurationThenRestart(setup: When, expectedState: ExpectedState) {
-        test(setup, expectedState) { router ->
+        test(setup, expectedState) { router, _ ->
             runOnMainSync {
                 router.pushIt(setup.pushConfiguration1!!)
                 router.pushIt(setup.pushConfiguration2!!)

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/RootNodeLifecycleTest.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/RootNodeLifecycleTest.kt
@@ -22,7 +22,7 @@ class RootNodeLifecycleTest {
 
     @Test
     fun whenActivityResumed_viewIsAttached() {
-        assertThat(node.isViewAttached).isTrue()
+        assertThat(node.isAttachedToView).isTrue()
     }
 
     @Test
@@ -45,7 +45,7 @@ class RootNodeLifecycleTest {
     fun whenActivityDestroyed_viewIsDetached() {
         ribsRule.finishActivitySync()
 
-        assertThat(node.isViewAttached).isFalse()
+        assertThat(node.isAttachedToView).isFalse()
     }
 
     @Test

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/helper/NodeState.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/helper/NodeState.kt
@@ -1,7 +1,10 @@
 package com.badoo.ribs.android.lifecycle.helper
 
 import android.arch.lifecycle.Lifecycle
-import android.arch.lifecycle.Lifecycle.State.*
+import android.arch.lifecycle.Lifecycle.State.CREATED
+import android.arch.lifecycle.Lifecycle.State.DESTROYED
+import android.arch.lifecycle.Lifecycle.State.RESUMED
+import android.arch.lifecycle.Lifecycle.State.STARTED
 
 data class NodeState(
     val attached: Boolean,
@@ -42,30 +45,27 @@ data class NodeState(
         )
     }
 
-    override fun toString(): String =
-        when {
-            attached && viewAttached -> {
-                when {
-                    ribLifeCycleState == RESUMED && viewLifeCycleState == RESUMED -> "ON_SCREEN"
-                    ribLifeCycleState == STARTED && viewLifeCycleState == STARTED -> "ON_SCREEN_PAUSED"
-                    ribLifeCycleState == CREATED && viewLifeCycleState == CREATED -> "ON_SCREEN_STOPPED"
-                    else -> "ON_SCREEN [!INVALID!] (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
-                }
-            }
+    override fun toString(): String = when {
+        attached && viewAttached -> onScreenToString()
+        attached && !viewAttached -> viewDetachedToString()
+        !attached && !viewAttached -> detachedToString()
+        else -> "!!! INVALID - ${super.toString()} !!!"
+    }
 
-            attached && !viewAttached -> {
-                when {
-                    ribLifeCycleState == CREATED && viewLifeCycleState == DESTROYED -> "VIEW_DETACHED"
-                    else -> "VIEW_DETACHED [!INVALID!] (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
-                }
-            }
+    private fun onScreenToString(): String = when {
+        ribLifeCycleState == RESUMED && viewLifeCycleState == RESUMED -> "ON_SCREEN"
+        ribLifeCycleState == STARTED && viewLifeCycleState == STARTED -> "ON_SCREEN_PAUSED"
+        ribLifeCycleState == CREATED && viewLifeCycleState == CREATED -> "ON_SCREEN_STOPPED"
+        else -> "ON_SCREEN [!INVALID!] (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
+    }
 
-            !attached && !viewAttached -> {
-                when {
-                    ribLifeCycleState == DESTROYED && viewLifeCycleState == DESTROYED -> "DETACHED"
-                    else -> "DETACHED [!INVALID!] (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
-                }
-            }
-            else -> "!!! INVALID - ${super.toString()} !!!"
-        }
+    private fun viewDetachedToString(): String = when {
+        ribLifeCycleState == CREATED && viewLifeCycleState == DESTROYED -> "VIEW_DETACHED"
+        else -> "VIEW_DETACHED [!INVALID!] (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
+    }
+
+    private fun detachedToString(): String = when {
+        ribLifeCycleState == DESTROYED && viewLifeCycleState == DESTROYED -> "DETACHED"
+        else -> "DETACHED [!INVALID!] (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
+    }
 }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/helper/NodeState.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/helper/NodeState.kt
@@ -1,20 +1,39 @@
 package com.badoo.ribs.android.lifecycle.helper
 
+import android.arch.lifecycle.Lifecycle
+
 data class NodeState(
     val attached: Boolean,
-    val viewAttached: Boolean
+    val viewAttached: Boolean,
+    val ribLifeCycleState: Lifecycle.State,
+    val viewLifeCycleState: Lifecycle.State
 ) {
     companion object {
-        val ON_SCREEN = NodeState(attached = true, viewAttached = true)
-        val VIEW_DETACHED = NodeState(attached = true, viewAttached = false)
-        val DETACHED = NodeState(attached = false, viewAttached = false)
+        val ON_SCREEN = NodeState(
+            attached = true,
+            viewAttached = true,
+            ribLifeCycleState = Lifecycle.State.RESUMED,
+            viewLifeCycleState = Lifecycle.State.RESUMED
+        )
+        val VIEW_DETACHED = NodeState(
+            attached = true,
+            viewAttached = false,
+            ribLifeCycleState = Lifecycle.State.CREATED,
+            viewLifeCycleState = Lifecycle.State.DESTROYED
+        )
+        val DETACHED = NodeState(
+            attached = false,
+            viewAttached = false,
+            ribLifeCycleState = Lifecycle.State.DESTROYED,
+            viewLifeCycleState = Lifecycle.State.DESTROYED
+        )
     }
 
     override fun toString(): String =
         when {
-            attached && viewAttached -> "ON_SCREEN"
-            attached && !viewAttached -> "VIEW_DETACHED"
-            !attached && !viewAttached -> "DETACHED"
+            attached && viewAttached -> "ON_SCREEN (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
+            attached && !viewAttached -> "VIEW_DETACHED (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
+            !attached && !viewAttached -> "DETACHED (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
             else -> "!!! INVALID !!!"
         }
 }

--- a/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/helper/NodeState.kt
+++ b/android/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/lifecycle/helper/NodeState.kt
@@ -1,6 +1,7 @@
 package com.badoo.ribs.android.lifecycle.helper
 
 import android.arch.lifecycle.Lifecycle
+import android.arch.lifecycle.Lifecycle.State.*
 
 data class NodeState(
     val attached: Boolean,
@@ -12,28 +13,59 @@ data class NodeState(
         val ON_SCREEN = NodeState(
             attached = true,
             viewAttached = true,
-            ribLifeCycleState = Lifecycle.State.RESUMED,
-            viewLifeCycleState = Lifecycle.State.RESUMED
+            ribLifeCycleState = RESUMED,
+            viewLifeCycleState = RESUMED
+        )
+        val ON_SCREEN_PAUSED = NodeState(
+            attached = true,
+            viewAttached = true,
+            ribLifeCycleState = STARTED,
+            viewLifeCycleState = STARTED
+        )
+        val ON_SCREEN_STOPPED = NodeState(
+            attached = true,
+            viewAttached = true,
+            ribLifeCycleState = CREATED,
+            viewLifeCycleState = CREATED
         )
         val VIEW_DETACHED = NodeState(
             attached = true,
             viewAttached = false,
-            ribLifeCycleState = Lifecycle.State.CREATED,
-            viewLifeCycleState = Lifecycle.State.DESTROYED
+            ribLifeCycleState = CREATED,
+            viewLifeCycleState = DESTROYED
         )
         val DETACHED = NodeState(
             attached = false,
             viewAttached = false,
-            ribLifeCycleState = Lifecycle.State.DESTROYED,
-            viewLifeCycleState = Lifecycle.State.DESTROYED
+            ribLifeCycleState = DESTROYED,
+            viewLifeCycleState = DESTROYED
         )
     }
 
     override fun toString(): String =
         when {
-            attached && viewAttached -> "ON_SCREEN (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
-            attached && !viewAttached -> "VIEW_DETACHED (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
-            !attached && !viewAttached -> "DETACHED (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
-            else -> "!!! INVALID !!!"
+            attached && viewAttached -> {
+                when {
+                    ribLifeCycleState == RESUMED && viewLifeCycleState == RESUMED -> "ON_SCREEN"
+                    ribLifeCycleState == STARTED && viewLifeCycleState == STARTED -> "ON_SCREEN_PAUSED"
+                    ribLifeCycleState == CREATED && viewLifeCycleState == CREATED -> "ON_SCREEN_STOPPED"
+                    else -> "ON_SCREEN [!INVALID!] (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
+                }
+            }
+
+            attached && !viewAttached -> {
+                when {
+                    ribLifeCycleState == CREATED && viewLifeCycleState == DESTROYED -> "VIEW_DETACHED"
+                    else -> "VIEW_DETACHED [!INVALID!] (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
+                }
+            }
+
+            !attached && !viewAttached -> {
+                when {
+                    ribLifeCycleState == DESTROYED && viewLifeCycleState == DESTROYED -> "DETACHED"
+                    else -> "DETACHED [!INVALID!] (rib: $ribLifeCycleState / view: $viewLifeCycleState)"
+                }
+            }
+            else -> "!!! INVALID - ${super.toString()} !!!"
         }
 }

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
@@ -95,8 +95,7 @@ open class Node<V : RibView>(
     private var savedInstanceState: Bundle? = null
     internal open var savedViewState: SparseArray<Parcelable> = SparseArray()
 
-    // TODO rename to isAttachedToView / isOnScreen (as it should not imply we have view)
-    internal var isViewAttached: Boolean = false
+    internal var isAttachedToView: Boolean = false
         private set
 
     fun getChildren(): List<Node<*>> =
@@ -104,7 +103,7 @@ open class Node<V : RibView>(
 
     open fun attachToView(parentViewGroup: ViewGroup) {
         this.parentViewGroup = parentViewGroup
-        isViewAttached = true
+        isAttachedToView = true
         view = createView(parentViewGroup)
         view?.let {
             parentViewGroup.addView(it.androidView)
@@ -122,7 +121,7 @@ open class Node<V : RibView>(
         viewFactory?.invoke(parentViewGroup)
 
     internal fun attachChildView(child: Node<*>) {
-        if (isViewAttached) {
+        if (isAttachedToView) {
             child.attachToView(
                 // parentViewGroup is guaranteed to be non-null if and only if view is attached
                 view?.getParentViewForChild(child.identifier) ?: parentViewGroup!!
@@ -153,7 +152,7 @@ open class Node<V : RibView>(
         }
 
         view = null
-        isViewAttached = false
+        isAttachedToView = false
         this.parentViewGroup = null
     }
 
@@ -166,7 +165,7 @@ open class Node<V : RibView>(
     open fun handleBackPress(): Boolean {
         ribRefWatcher.logBreadcrumb("BACKPRESS", null, null)
         return children
-                .filter { it.isViewAttached }
+                .filter { it.isAttachedToView }
                 .any { it.handleBackPress() }
             || interactor.handleBackPress()
             || router.popBackStack()
@@ -221,7 +220,7 @@ open class Node<V : RibView>(
     }
 
     open fun onDetach() {
-        if (isViewAttached) {
+        if (isAttachedToView) {
             RIBs.errorHandler.handleNonFatalError(
                 "View was not detached before node detach!",
                 RuntimeException("View was not detached before node detach!")
@@ -331,7 +330,7 @@ open class Node<V : RibView>(
     }
 
     private fun updateToStateIfViewAttached(state: Lifecycle.State) {
-        if (isViewAttached) {
+        if (isAttachedToView) {
             ribLifecycleRegistry.markState(state)
             view?.let { viewLifecycleRegistry.markState(state) }
         }

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
@@ -139,20 +139,22 @@ open class Node<V : RibView>(
         viewFactory?.invoke(parentViewGroup)
 
     open fun detachFromView() {
-        onPauseInternal()
-        onStopInternal()
-        router.onDetachView()
+        if (isAttachedToView) {
+            onPauseInternal()
+            onStopInternal()
+            router.onDetachView()
 
-        if (!isViewless) {
-            view!!.let {
-                parentViewGroup!!.removeView(it.androidView)
-                viewLifecycleRegistry.handleLifecycleEvent(ON_DESTROY)
+            if (!isViewless) {
+                view!!.let {
+                    parentViewGroup!!.removeView(it.androidView)
+                    viewLifecycleRegistry.handleLifecycleEvent(ON_DESTROY)
+                }
             }
-        }
 
-        view = null
-        isAttachedToView = false
-        this.parentViewGroup = null
+            view = null
+            isAttachedToView = false
+            this.parentViewGroup = null
+        }
     }
 
     open fun onDetach() {

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
@@ -183,8 +183,12 @@ open class Node<V : RibView>(
             "ATTACHED", childNode.javaClass.simpleName, this.javaClass.simpleName
         )
 
-        childNode.externalLifecycleRegistry.markState(externalLifecycleRegistry.currentState)
+        childNode.inheritExternalLifecycle(externalLifecycleRegistry)
         childNode.onAttach(bundle)
+    }
+
+    private fun inheritExternalLifecycle(lifecycleRegistry: LifecycleRegistry) {
+        externalLifecycleRegistry.markState(lifecycleRegistry.currentState)
     }
 
     /**

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/action/single/ActivateAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/action/single/ActivateAction.kt
@@ -43,7 +43,7 @@ internal object ActivateAction : ResolvedSingleConfigurationAction() {
 
     private fun Node<*>.attachParentedViews(nodes: List<Node.Descriptor>) {
         nodes.forEach {
-            if (it.viewAttachMode == Node.ViewAttachMode.PARENT && !it.node.isViewAttached) {
+            if (it.viewAttachMode == Node.ViewAttachMode.PARENT && !it.node.isAttachedToView) {
                 attachChildView(it.node)
             }
         }

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/InteractorTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/InteractorTest.kt
@@ -30,7 +30,7 @@ class InteractorTest {
 
     @Test
     fun `Tag is generated automatically`() {
-        interactor.onAttach(null)
+        interactor.onAttach(null, mock())
         assertNotNull(interactor.tag)
     }
 
@@ -45,7 +45,7 @@ class InteractorTest {
     fun `Tag is restored from bundle`() {
         val savedInstanceState = mock<Bundle>()
         whenever(savedInstanceState.getString(KEY_TAG)).thenReturn("abcdef")
-        interactor.onAttach(savedInstanceState)
+        interactor.onAttach(savedInstanceState, mock())
         assertEquals("abcdef", interactor.tag)
     }
 }

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
@@ -161,7 +161,7 @@ class NodeTest {
 
         node.onDetach()
 
-        assertEquals(false, node.isViewAttached)
+        assertEquals(false, node.isAttachedToView)
     }
 
     @Test
@@ -327,20 +327,20 @@ class NodeTest {
 
     @Test
     fun `isViewAttached flag is initially false`() {
-        assertEquals(false, node.isViewAttached)
+        assertEquals(false, node.isAttachedToView)
     }
 
     @Test
     fun `attachToView() sets isViewAttached flag to true`() {
         node.attachToView(parentViewGroup)
-        assertEquals(true, node.isViewAttached)
+        assertEquals(true, node.isAttachedToView)
     }
 
     @Test
     fun `onDetachFromView() resets isViewAttached flag to false`() {
         node.attachToView(parentViewGroup)
         node.detachFromView()
-        assertEquals(false, node.isViewAttached)
+        assertEquals(false, node.isAttachedToView)
     }
 
     @Test

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
@@ -107,7 +107,7 @@ class NodeTest {
     @Test
     fun `onAttach() notifies Interactor`() {
         node.onAttach(null)
-        verify(interactor).onAttach(null)
+        verify(interactor).onAttach(null, node.ribLifecycleRegistry)
     }
 
     @Test
@@ -125,7 +125,7 @@ class NodeTest {
         val childBundle: Bundle = mock()
         whenever(bundle.getBundle(KEY_INTERACTOR)).thenReturn(childBundle)
         node.onAttach(bundle)
-        verify(interactor).onAttach(childBundle)
+        verify(interactor).onAttach(childBundle, node.ribLifecycleRegistry)
     }
 
     @Test
@@ -199,30 +199,6 @@ class NodeTest {
         node.onSaveInstanceState(bundle)
         verify(interactor).onSaveInstanceState(captor.capture())
         verify(bundle).putBundle(KEY_INTERACTOR, captor.firstValue)
-    }
-
-    @Test
-    fun `onStart() is forwarded to Interactor`() {
-        node.onStart()
-        verify(interactor).onStart()
-    }
-
-    @Test
-    fun `onStop() is forwarded to Interactor`() {
-        node.onStop()
-        verify(interactor).onStop()
-    }
-
-    @Test
-    fun `onPause() is forwarded to Interactor`() {
-        node.onPause()
-        verify(interactor).onPause()
-    }
-
-    @Test
-    fun `onResume()() is forwarded to Interactor`() {
-        node.onResume()
-        verify(interactor).onResume()
     }
 
     @Test
@@ -491,13 +467,13 @@ class NodeTest {
     @Test
     fun `When current Node has a view, attachToView() notifies Interactor of view creation`() {
         node.attachToView(parentViewGroup)
-        verify(interactor).onViewCreated(view)
+        verify(interactor).onViewCreated(node.viewLifecycleRegistry, view)
     }
 
     @Test
     fun `When current Node doesn't have a view, attachToView() does not notify Interactor of view creation`() {
         whenever(viewFactory.invoke(parentViewGroup)).thenReturn(null)
         node.attachToView(parentViewGroup)
-        verify(interactor, never()).onViewCreated(anyOrNull())
+        verify(interactor, never()).onViewCreated(anyOrNull(), anyOrNull())
     }
 }

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
@@ -78,9 +78,9 @@ class NodeTest {
     }
 
     private fun addChildren() {
-        child1 = TestNode(object : RandomOtherNode1 {})
-        child2 = TestNode(object : RandomOtherNode2 {})
-        child3 = TestNode(object : RandomOtherNode3 {})
+        child1 = TestNode(identifier = object : RandomOtherNode1 {}, viewFactory = null)
+        child2 = TestNode(identifier = object : RandomOtherNode2 {}, viewFactory = null)
+        child3 = TestNode(identifier = object : RandomOtherNode3 {}, viewFactory = null)
         allChildren = listOf(child1, child2, child3)
         node.children.addAll(allChildren)
     }
@@ -145,7 +145,7 @@ class NodeTest {
         val errorHandler = mock<RIBs.ErrorHandler>()
         RIBs.clearErrorHandler()
         RIBs.errorHandler = errorHandler
-        node.attachToView(mock())
+        node.attachToView(parentViewGroup)
 
         node.onDetach()
 
@@ -157,7 +157,7 @@ class NodeTest {
         val errorHandler = mock<RIBs.ErrorHandler>()
         RIBs.clearErrorHandler()
         RIBs.errorHandler = errorHandler
-        node.attachToView(mock())
+        node.attachToView(parentViewGroup)
 
         node.onDetach()
 
@@ -459,21 +459,33 @@ class NodeTest {
     }
 
     @Test
-    fun `When current Node doesn't have a view, attachToView() does not add anything to parentViewGroup`() {
-        whenever(viewFactory.invoke(parentViewGroup)).thenReturn(null)
-        node.attachToView(parentViewGroup)
-        verify(parentViewGroup, never()).addView(anyOrNull())
-    }
-
-    @Test
     fun `When current Node has a view, attachToView() notifies Interactor of view creation`() {
         node.attachToView(parentViewGroup)
         verify(interactor).onViewCreated(node.viewLifecycleRegistry, view)
     }
 
     @Test
+    fun `When current Node doesn't have a view, attachToView() does not add anything to parentViewGroup`() {
+        node = Node(
+            identifier = object : TestPublicRibInterface {},
+            viewFactory = null,
+            router = router,
+            interactor = interactor
+        )
+
+        node.attachToView(parentViewGroup)
+        verify(parentViewGroup, never()).addView(anyOrNull())
+    }
+
+    @Test
     fun `When current Node doesn't have a view, attachToView() does not notify Interactor of view creation`() {
-        whenever(viewFactory.invoke(parentViewGroup)).thenReturn(null)
+        node = Node(
+            identifier = object : TestPublicRibInterface {},
+            viewFactory = null,
+            router = router,
+            interactor = interactor
+        )
+
         node.attachToView(parentViewGroup)
         verify(interactor, never()).onViewCreated(anyOrNull(), anyOrNull())
     }

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
@@ -400,9 +400,10 @@ class NodeTest {
 
     @Test
     fun `attachChild() does not imply attachToView when Android view system is not available`() {
-        val child = mock<Node<*>>()
+        val childViewFactory = mock<ViewFactory<TestView>>()
+        val child = TestNode(mock(), childViewFactory)
         node.attachChildNode(child, null)
-        verify(child, never()).attachToView(parentViewGroup)
+        verify(childViewFactory, never()).invoke(parentViewGroup)
     }
 
     @Test

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestNode.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestNode.kt
@@ -3,12 +3,14 @@ package com.badoo.ribs.core.helper
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.Rib
 import com.nhaarman.mockitokotlin2.mock
+import com.badoo.ribs.core.view.ViewFactory
 
 class TestNode(
-    identifier: Rib
+    identifier: Rib,
+    viewFactory: ViewFactory<TestView> = mock()
 ) : Node<TestView>(
     identifier = identifier,
-    viewFactory = mock(),
+    viewFactory = viewFactory,
     router = mock(),
     interactor = mock()
 ) {

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestNode.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestNode.kt
@@ -7,7 +7,7 @@ import com.badoo.ribs.core.view.ViewFactory
 
 class TestNode(
     identifier: Rib,
-    viewFactory: ViewFactory<TestView> = mock()
+    viewFactory: ViewFactory<TestView>? = mock()
 ) : Node<TestView>(
     identifier = identifier,
     viewFactory = viewFactory,


### PR DESCRIPTION
Implemented in this ticket:
- Moved lifecycle completely from `Interactor`
- `Node` will go through pause & stop when view is detached (technically when in back stack)
- `Node` will go through start & resume when view is attached (technically when most recent in back stack)
- `Node` keeps track of external lifecycle (e.g. hosting `Activity`), so that its state cannot go higher than that of the external (e.g. `Activity` is paused, but `Node` is reattached, it cannot go to resumed)
- child `Nodes` that are created / attached, assume the external lifecycle from their parents (as otherwise they wouldn't know it until next external lifecycle callback)
- tests that cover the above regardless of when the external lifecycle changes while pausing / popping test configurations

Not supported in this ticket:
- Overlays do not affect underlying content RIB lifecycle (no pause by covering)
- RIBs in dialogs will be paused, which is incorrect: dialog covers `Activity`, `Activity` gets paused, pause gets passed down to all children, including the one living inside the dialog.