### PR TITLE
Change root tag to ConstraintLayout

### DIFF
--- a/android/templates/src/main/res/layout/rib_foo_bar.xml
+++ b/android/templates/src/main/res/layout/rib_foo_bar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.badoo.ribs.template.rib_with_view.foo_bar.FooBarViewImpl
+<android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/rib_foo_bar"
@@ -15,4 +15,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-</com.badoo.ribs.template.rib_with_view.foo_bar.FooBarViewImpl>
+</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Since ViewImpl is no longer an Android view, it's a mistake that the xml still tried to inflate it. This PR corrects it.