### PR TITLE
Add java plugin to fix compatibility issue

### DIFF
--- a/android/tooling/rib-intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/android/tooling/rib-intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,7 @@
 
     <idea-version since-build="163"/>
 
+    <depends optional="false">com.intellij.modules.java</depends>
     <depends optional="false">org.jetbrains.android</depends>
     <depends optional="false">org.jetbrains.kotlin</depends>
 


### PR DESCRIPTION
> Your plugin has a lot of compatibility problems with build 192.* due to Java functionality was extracted to a separate plugin in IntelliJ IDEA, and if your plugin use classes from the Java part of IntelliJ API you should declare a dependency on com.intellij.modules.java module. Please add this dependency and re-upload your plugin. If you use 'gradle-intellij-plugin', you can add plugins "java" to intellij configuration in your build.gradle file.

>Please see this post https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/