### PR TITLE
Make feature, interactor and router internal in template

### DIFF
--- a/android/templates/release-0.8/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/FooBarInteractor.kt
+++ b/android/templates/release-0.8/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/FooBarInteractor.kt
@@ -20,7 +20,7 @@ import com.badoo.ribs.template.rib_with_view.foo_bar.mapper.ViewEventToWish
 import io.reactivex.ObservableSource
 import io.reactivex.functions.Consumer
 
-class FooBarInteractor(
+internal class FooBarInteractor(
     savedInstanceState: Bundle?,
     router: Router<Configuration, *, Content, Overlay, FooBarView>,
     private val input: ObservableSource<FooBar.Input>,

--- a/android/templates/release-0.8/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/FooBarRouter.kt
+++ b/android/templates/release-0.8/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/FooBarRouter.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.template.rib_with_view.foo_bar.FooBarRouter.Configuration.
 import com.badoo.ribs.template.rib_with_view.foo_bar.FooBarRouter.Configuration.Permanent
 import kotlinx.android.parcel.Parcelize
 
-class FooBarRouter(
+internal class FooBarRouter(
     savedInstanceState: Bundle?
 ): Router<Configuration, Permanent, Content, Overlay, FooBarView>(
     savedInstanceState = savedInstanceState,

--- a/android/templates/release-0.8/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/feature/FooBarFeature.kt
+++ b/android/templates/release-0.8/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/feature/FooBarFeature.kt
@@ -12,7 +12,7 @@ import com.badoo.ribs.template.rib_with_view.foo_bar.feature.FooBarFeature.Wish
 import io.reactivex.Observable
 import io.reactivex.Observable.empty
 
-class FooBarFeature : ActorReducerFeature<Wish, Effect, State, News>(
+internal class FooBarFeature : ActorReducerFeature<Wish, Effect, State, News>(
     initialState = State(),
     bootstrapper = BootStrapperImpl(),
     actor = ActorImpl(),

--- a/android/templates/snapshot/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/FooBarInteractor.kt
+++ b/android/templates/snapshot/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/FooBarInteractor.kt
@@ -20,7 +20,7 @@ import com.badoo.ribs.template.rib_with_view.foo_bar.mapper.ViewEventToWish
 import io.reactivex.ObservableSource
 import io.reactivex.functions.Consumer
 
-class FooBarInteractor(
+internal class FooBarInteractor(
     savedInstanceState: Bundle?,
     router: Router<Configuration, *, Content, Overlay, FooBarView>,
     private val input: ObservableSource<FooBar.Input>,

--- a/android/templates/snapshot/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/FooBarRouter.kt
+++ b/android/templates/snapshot/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/FooBarRouter.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.template.rib_with_view.foo_bar.FooBarRouter.Configuration.
 import com.badoo.ribs.template.rib_with_view.foo_bar.FooBarRouter.Configuration.Permanent
 import kotlinx.android.parcel.Parcelize
 
-class FooBarRouter(
+internal class FooBarRouter(
     savedInstanceState: Bundle?
 ): Router<Configuration, Permanent, Content, Overlay, FooBarView>(
     savedInstanceState = savedInstanceState,

--- a/android/templates/snapshot/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/feature/FooBarFeature.kt
+++ b/android/templates/snapshot/src/main/java/com/badoo/ribs/template/rib_with_view/foo_bar/feature/FooBarFeature.kt
@@ -12,7 +12,7 @@ import com.badoo.ribs.template.rib_with_view.foo_bar.feature.FooBarFeature.Wish
 import io.reactivex.Observable
 import io.reactivex.Observable.empty
 
-class FooBarFeature : ActorReducerFeature<Wish, Effect, State, News>(
+internal class FooBarFeature : ActorReducerFeature<Wish, Effect, State, News>(
     initialState = State(),
     bootstrapper = BootStrapperImpl(),
     actor = ActorImpl(),


### PR DESCRIPTION
Following https://github.com/badoo/RIBs/pull/105, make Feature, Interactor and Router classes internal too. They are not exposed by public constructor anymore.