### PR TITLE
Update RIBs templates to trigger plugin push

### DIFF
--- a/android/templates/snapshot/src/main/AndroidManifest.xml
+++ b/android/templates/snapshot/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-        package="com.badoo.ribs.template">
-</manifest>
+<manifest package="com.badoo.ribs.template" />


### PR DESCRIPTION
We had this issue while publishing the plugin:
```
> Task :tooling:rib-intellij-plugin:publishPlugin FAILED
Failed to upload plugin: You have not accepted JetBrains Plugin Marketplace agreement.
```

The license has been accepted, now publishing should work