### PR TITLE
Store gradle cache for the build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
               with:
                   path: ~/.gradle/caches
                   key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/gradle/dependencies.gradle') }}
-
             - name: Unit tests
               run: ./gradlew testDebugUnitTest
               working-directory: ./android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
         strategy:
             matrix:
-                api-level: [21,25,29]
+                api-level: [22,25,29]
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         timeout-minutes: 25
         env:
             JAVA_TOOL_OPTIONS: -Xmx6g
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.parallel=true
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1
@@ -46,7 +46,7 @@ jobs:
         timeout-minutes: 20
         env:
             JAVA_TOOL_OPTIONS: -Xmx4g
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.parallel=true
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1
@@ -67,7 +67,7 @@ jobs:
         timeout-minutes: 60
         env:
             JAVA_TOOL_OPTIONS: -Xmx4g
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.parallel=true
         strategy:
             matrix:
                 api-level: [29]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             - uses: actions/cache@v1
               with:
                   path: ~/.gradle/caches
-                  key: gradle-${{ runner.os }}-${{ hashFiles('/android/**/build.gradle') }}-${{ hashFiles('/android/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('/android/gradle/dependencies.gradle') }}
+                  key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/gradle/dependencies.gradle') }}
 
             - name: Assemble
               run: ./gradlew assemble
@@ -53,6 +53,11 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
+            - uses: actions/cache@v1
+              with:
+                  path: ~/.gradle/caches
+                  key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/gradle/dependencies.gradle') }}
+
             - name: Unit tests
               run: ./gradlew testDebugUnitTest
               working-directory: ./android
@@ -66,13 +71,18 @@ jobs:
             GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
         strategy:
             matrix:
-                api-level: [21,29]
+                api-level: [29]
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
+            - uses: actions/cache@v1
+              with:
+                  path: ~/.gradle/caches
+                  key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/gradle/dependencies.gradle') }}
+
 
             - name: Instrumentation tests
               uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         timeout-minutes: 60
         env:
             JAVA_TOOL_OPTIONS: -Xmx4g
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.parallel=true
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
         strategy:
             matrix:
                 api-level: [21,25,29]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
+            - uses: actions/cache@v1
+              with:
+                  path: ~/.gradle/caches
+                  key: gradle-${{ runner.os }}-${{ hashFiles('/android/**/build.gradle') }}-${{ hashFiles('/android/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('/android/gradle/dependencies.gradle') }}
+
             - name: Assemble
               run: ./gradlew assemble
               working-directory: ./android              

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.parallel=true
         strategy:
             matrix:
-                api-level: [29]
+                api-level: [21,25,29]
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

- Store Gradle cache for jobs
- Add `org.gradle.parallel=true` Gradle option for build and unit tests
- Use 22, 25, 29 sdk versions for ui test runs

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
