### PR TITLE
Call RoutingActions with BuildContext

### DIFF
--- a/android/app-example/src/test/java/com/badoo/ribs/example/rib/switcher/SwitcherRouterTest.kt
+++ b/android/app-example/src/test/java/com/badoo/ribs/example/rib/switcher/SwitcherRouterTest.kt
@@ -1,8 +1,8 @@
 package com.badoo.ribs.example.rib.switcher
 
+import com.badoo.ribs.core.builder.BuildContext.Companion.root
 import com.badoo.ribs.core.builder.BuildParams
 import com.badoo.ribs.core.routing.action.DialogRoutingAction
-import com.badoo.ribs.core.routing.portal.AncestryInfo
 import com.badoo.ribs.dialog.DialogLauncher
 import com.badoo.ribs.example.rib.blocker.BlockerBuilder
 import com.badoo.ribs.example.rib.blocker.BlockerView
@@ -69,7 +69,7 @@ class SwitcherRouterTest {
     @Test
     fun `Permanent_Menu configuration resolves to correct Node`() {
         val routingAction = router.resolveConfiguration(Permanent.Menu).apply { execute() }
-        val nodes = routingAction.buildNodes(AncestryInfo.Root, emptyList())
+        val nodes = routingAction.buildNodes(listOf(root(null)))
 
         assertThat(nodes).hasSize(1)
         assertThat(nodes.first()).isEqualTo(menuNode)
@@ -78,7 +78,7 @@ class SwitcherRouterTest {
     @Test
     fun `Content_Hello configuration resolves to correct Node`() {
         val routingAction = router.resolveConfiguration(Content.Hello).apply { execute() }
-        val nodes = routingAction.buildNodes(AncestryInfo.Root, emptyList())
+        val nodes = routingAction.buildNodes(listOf(root(null)))
 
         assertThat(nodes).hasSize(1)
         assertThat(nodes.first()).isEqualTo(helloWorldNode)
@@ -96,7 +96,7 @@ class SwitcherRouterTest {
     @Test
     fun `Content_Foo configuration resolves to correct Node`() {
         val routingAction = router.resolveConfiguration(Content.Foo).apply { execute() }
-        val nodes = routingAction.buildNodes(AncestryInfo.Root, emptyList())
+        val nodes = routingAction.buildNodes(listOf(root(null)))
 
         assertThat(nodes).hasSize(1)
         assertThat(nodes.first()).isEqualTo(fooBarNode)
@@ -114,7 +114,7 @@ class SwitcherRouterTest {
     @Test
     fun `Content_DialogsExample configuration resolves to correct Node`() {
         val routingAction = router.resolveConfiguration(Content.DialogsExample).apply { execute() }
-        val nodes = routingAction.buildNodes(AncestryInfo.Root, emptyList())
+        val nodes = routingAction.buildNodes(listOf(root(null)))
 
         assertThat(nodes).hasSize(1)
         assertThat(nodes.first()).isEqualTo(dialogExampleNode)
@@ -132,7 +132,7 @@ class SwitcherRouterTest {
     @Test
     fun `Content_Blocker configuration resolves to correct Node`() {
         val routingAction = router.resolveConfiguration(Content.Blocker).apply { execute() }
-        val nodes = routingAction.buildNodes(AncestryInfo.Root, emptyList())
+        val nodes = routingAction.buildNodes(listOf(root(null)))
 
         assertThat(nodes).hasSize(1)
         assertThat(nodes.first()).isEqualTo(blockerNode)

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import com.badoo.ribs.core.Rib.Identifier
+import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.builder.BuildParams
 import com.badoo.ribs.core.routing.configuration.ConfigurationResolver
 import com.badoo.ribs.core.routing.portal.AncestryInfo
@@ -61,15 +62,18 @@ open class Node<V : RibView>(
     open val identifier: Rib.Identifier =
         buildParams.identifier
 
+    internal val buildContext: BuildContext =
+        buildParams.buildContext
+
     /**
      * TODO PortalRouter.Configuration.Portal can then work directly with a @Parcelize AncestryInfo,
      *  which was not possible until now.
      */
     internal val ancestryInfo: AncestryInfo =
-        buildParams.buildContext.ancestryInfo
+        buildContext.ancestryInfo
 
     internal open val attachMode: AttachMode =
-        buildParams.buildContext.attachMode
+        buildContext.attachMode
 
     val resolver: ConfigurationResolver<out Parcelable>? = router
     private val savedInstanceState = buildParams.savedInstanceState?.getBundle(BUNDLE_KEY)

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildContext.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildContext.kt
@@ -3,8 +3,9 @@ package com.badoo.ribs.core.builder
 import android.os.Bundle
 import com.badoo.ribs.core.AttachMode
 import com.badoo.ribs.core.routing.portal.AncestryInfo
+import com.badoo.ribs.customisation.RibCustomisationDirectory
 
-class BuildContext internal constructor(
+data class BuildContext internal constructor(
     val ancestryInfo: AncestryInfo,
     val attachMode: AttachMode = AttachMode.PARENT,
     val savedInstanceState: Bundle?

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildContext.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildContext.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.core.builder
 import android.os.Bundle
 import com.badoo.ribs.core.AttachMode
 import com.badoo.ribs.core.routing.portal.AncestryInfo
-import com.badoo.ribs.customisation.RibCustomisationDirectory
 
 data class BuildContext internal constructor(
     val ancestryInfo: AncestryInfo,

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/AddToRecyclerViewRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/AddToRecyclerViewRoutingAction.kt
@@ -1,23 +1,19 @@
 package com.badoo.ribs.core.routing.action
 
-import android.os.Bundle
 import com.badoo.ribs.core.AttachMode
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.builder.NodeFactory
-import com.badoo.ribs.core.routing.portal.AncestryInfo
 
 open class AddToRecyclerViewRoutingAction(
     private val nodeFactory: NodeFactory
 ) : RoutingAction {
 
-    override fun buildNodes(ancestryInfo: AncestryInfo, bundles: List<Bundle?>): List<Node<*>> =
+    override fun buildNodes(buildContexts: List<BuildContext>): List<Node<*>> =
         listOf(
             nodeFactory.invoke(
-                BuildContext(
-                    ancestryInfo = ancestryInfo,
-                    attachMode = AttachMode.EXTERNAL,
-                    savedInstanceState = bundles.firstOrNull()
+                buildContext.copy(
+                    attachMode = AttachMode.EXTERNAL
                 )
             )
         )

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/AddToRecyclerViewRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/AddToRecyclerViewRoutingAction.kt
@@ -9,10 +9,12 @@ open class AddToRecyclerViewRoutingAction(
     private val nodeFactory: NodeFactory
 ) : RoutingAction {
 
+    override val nbNodesToBuild: Int = 1
+
     override fun buildNodes(buildContexts: List<BuildContext>): List<Node<*>> =
         listOf(
             nodeFactory.invoke(
-                buildContext.copy(
+                buildContexts.first().copy(
                     attachMode = AttachMode.EXTERNAL
                 )
             )

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/AttachRibRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/AttachRibRoutingAction.kt
@@ -6,19 +6,25 @@ import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.builder.NodeFactory
 import com.badoo.ribs.core.routing.portal.AncestryInfo
+import com.badoo.ribs.core.view.RibView
+import com.badoo.ribs.customisation.RibCustomisationDirectory
 
 open class AttachRibRoutingAction(
     private val nodeFactory: NodeFactory
 ) : RoutingAction {
 
-    override fun buildNodes(ancestryInfo: AncestryInfo, bundles: List<Bundle?>): List<Node<*>> =
+    override fun buildNodes(
+        buildContexts: List<BuildContext>
+    ): List<Node<*>> =
         listOf(
             nodeFactory.invoke(
-                BuildContext(
-                    ancestryInfo = ancestryInfo,
-                    attachMode = AttachMode.PARENT,
-                    savedInstanceState = bundles.firstOrNull()
-                )
+                buildContext
+//                    (
+//                    ancestryInfo = ancestryInfo,
+//                    attachMode = AttachMode.PARENT,
+//                    savedInstanceState = bundles.firstOrNull(),
+//                    customisations = customisations
+//                )
             )
         )
 

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/AttachRibRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/AttachRibRoutingAction.kt
@@ -1,30 +1,19 @@
 package com.badoo.ribs.core.routing.action
 
-import android.os.Bundle
-import com.badoo.ribs.core.AttachMode
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.builder.NodeFactory
-import com.badoo.ribs.core.routing.portal.AncestryInfo
-import com.badoo.ribs.core.view.RibView
-import com.badoo.ribs.customisation.RibCustomisationDirectory
 
 open class AttachRibRoutingAction(
     private val nodeFactory: NodeFactory
 ) : RoutingAction {
 
-    override fun buildNodes(
-        buildContexts: List<BuildContext>
-    ): List<Node<*>> =
+    override val nbNodesToBuild: Int = 1
+
+    override fun buildNodes(buildContexts: List<BuildContext>): List<Node<*>> =
         listOf(
             nodeFactory.invoke(
-                buildContext
-//                    (
-//                    ancestryInfo = ancestryInfo,
-//                    attachMode = AttachMode.PARENT,
-//                    savedInstanceState = bundles.firstOrNull(),
-//                    customisations = customisations
-//                )
+                buildContexts.first()
             )
         )
 

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/CompositeRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/CompositeRoutingAction.kt
@@ -2,12 +2,12 @@ package com.badoo.ribs.core.routing.action
 
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.builder.BuildContext
-import com.badoo.ribs.core.view.RibView
-import com.badoo.ribs.core.routing.portal.AncestryInfo
 
 class CompositeRoutingAction(
     private vararg val routingActions: RoutingAction
 ) : RoutingAction {
+
+    override val nbNodesToBuild: Int = routingActions.asList().fold(0) { acc, r -> acc + r.nbNodesToBuild }
 
     constructor(routingActions: List<RoutingAction>) : this(*routingActions.toTypedArray())
 

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/CompositeRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/CompositeRoutingAction.kt
@@ -7,7 +7,7 @@ class CompositeRoutingAction(
     private vararg val routingActions: RoutingAction
 ) : RoutingAction {
 
-    override val nbNodesToBuild: Int = routingActions.asList().fold(0) { acc, r -> acc + r.nbNodesToBuild }
+    override val nbNodesToBuild: Int = routingActions.fold(0) { acc, r -> acc + r.nbNodesToBuild }
 
     constructor(routingActions: List<RoutingAction>) : this(*routingActions.toTypedArray())
 

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/CompositeRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/CompositeRoutingAction.kt
@@ -1,7 +1,8 @@
 package com.badoo.ribs.core.routing.action
 
-import android.os.Bundle
 import com.badoo.ribs.core.Node
+import com.badoo.ribs.core.builder.BuildContext
+import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.routing.portal.AncestryInfo
 
 class CompositeRoutingAction(
@@ -10,11 +11,10 @@ class CompositeRoutingAction(
 
     constructor(routingActions: List<RoutingAction>) : this(*routingActions.toTypedArray())
 
-    override fun buildNodes(ancestryInfo: AncestryInfo, bundles: List<Bundle?>) : List<Node<*>> =
+    override fun buildNodes(buildContexts: List<BuildContext>) : List<Node<*>> =
         routingActions.mapIndexed { index, routingAction ->
             routingAction.buildNodes(
-                ancestryInfo = ancestryInfo,
-                bundles = bundles.getOrNull(index)?.let { listOf(it) } ?: emptyList()
+                buildContexts = buildContexts.getOrNull(index)?.let { listOf(it) } ?: emptyList()
             )
         }.flatten()
 

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/CompositeRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/CompositeRoutingAction.kt
@@ -14,7 +14,7 @@ class CompositeRoutingAction(
     override fun buildNodes(buildContexts: List<BuildContext>) : List<Node<*>> =
         routingActions.mapIndexed { index, routingAction ->
             routingAction.buildNodes(
-                buildContexts = buildContexts.getOrNull(index)?.let { listOf(it) } ?: emptyList()
+                buildContexts = listOfNotNull(buildContexts.getOrNull(index))
             )
         }.flatten()
 

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/DialogRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/DialogRoutingAction.kt
@@ -3,8 +3,6 @@ package com.badoo.ribs.core.routing.action
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.Router
 import com.badoo.ribs.core.builder.BuildContext
-import com.badoo.ribs.core.view.RibView
-import com.badoo.ribs.core.routing.portal.AncestryInfo
 import com.badoo.ribs.dialog.Dialog
 import com.badoo.ribs.dialog.DialogLauncher
 
@@ -13,6 +11,8 @@ class DialogRoutingAction<Event : Any>(
     private val dialogLauncher: DialogLauncher,
     private val dialog: Dialog<Event>
 ) : RoutingAction {
+
+    override val nbNodesToBuild: Int = 1
 
     override fun buildNodes(buildContexts: List<BuildContext>) : List<Node<*>> =
         dialog.buildNodes(buildContexts.first())

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/DialogRoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/DialogRoutingAction.kt
@@ -1,8 +1,9 @@
 package com.badoo.ribs.core.routing.action
 
-import android.os.Bundle
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.Router
+import com.badoo.ribs.core.builder.BuildContext
+import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.routing.portal.AncestryInfo
 import com.badoo.ribs.dialog.Dialog
 import com.badoo.ribs.dialog.DialogLauncher
@@ -13,8 +14,8 @@ class DialogRoutingAction<Event : Any>(
     private val dialog: Dialog<Event>
 ) : RoutingAction {
 
-    override fun buildNodes(ancestryInfo: AncestryInfo, bundles: List<Bundle?>) : List<Node<*>> =
-        dialog.buildNodes(ancestryInfo, bundles)
+    override fun buildNodes(buildContexts: List<BuildContext>) : List<Node<*>> =
+        dialog.buildNodes(buildContexts.first())
 
     override fun execute() {
         dialogLauncher.show(dialog, onClose = {

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/InvokeOnCleanUp.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/InvokeOnCleanUp.kt
@@ -4,6 +4,8 @@ class InvokeOnCleanup(
     private val f: () -> Unit
 ) : RoutingAction {
 
+    override val nbNodesToBuild: Int = 0
+
     override fun cleanup() {
         f()
     }

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/InvokeOnExecute.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/InvokeOnExecute.kt
@@ -4,6 +4,8 @@ class InvokeOnExecute(
     private val onInvoke: () -> Unit
 ) : RoutingAction {
 
+    override val nbNodesToBuild: Int = 0
+
     override fun execute() {
         onInvoke()
     }

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/RoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/RoutingAction.kt
@@ -2,11 +2,14 @@ package com.badoo.ribs.core.routing.action
 
 import android.os.Bundle
 import com.badoo.ribs.core.Node
+import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.routing.portal.AncestryInfo
+import com.badoo.ribs.core.view.RibView
+import com.badoo.ribs.customisation.RibCustomisationDirectory
 
 interface RoutingAction {
 
-    fun buildNodes(ancestryInfo: AncestryInfo, bundles: List<Bundle?>) : List<Node<*>> =
+    fun buildNodes(buildContexts: List<BuildContext>): List<Node<*>> =
         emptyList()
 
     fun execute() {

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/RoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/RoutingAction.kt
@@ -1,14 +1,15 @@
 package com.badoo.ribs.core.routing.action
 
-import android.os.Bundle
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.builder.BuildContext
-import com.badoo.ribs.core.routing.portal.AncestryInfo
-import com.badoo.ribs.core.view.RibView
-import com.badoo.ribs.customisation.RibCustomisationDirectory
 
 interface RoutingAction {
 
+    val nbNodesToBuild: Int
+
+    /**
+     * Guaranteed by framework to receive a list of nbNodesToBuild elements
+     */
     fun buildNodes(buildContexts: List<BuildContext>): List<Node<*>> =
         emptyList()
 
@@ -23,7 +24,9 @@ interface RoutingAction {
 
     companion object {
         fun noop(): RoutingAction = object :
-            RoutingAction {}
+            RoutingAction {
+            override val nbNodesToBuild: Int = 0
+        }
     }
 }
 

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/RoutingAction.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/action/RoutingAction.kt
@@ -23,8 +23,7 @@ interface RoutingAction {
         null
 
     companion object {
-        fun noop(): RoutingAction = object :
-            RoutingAction {
+        fun noop(): RoutingAction = object : RoutingAction {
             override val nbNodesToBuild: Int = 0
         }
     }

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/ConfigurationContext.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/ConfigurationContext.kt
@@ -109,7 +109,7 @@ internal sealed class ConfigurationContext<C : Parcelable> {
 
         private fun buildNodes(routingAction: RoutingAction, parentNode: Node<*>): List<Node<*>> {
             val template = createBuildContext(routingAction, parentNode)
-            val buildContexts = MutableList(routingAction.nbNodesToBuild) {
+            val buildContexts = List(routingAction.nbNodesToBuild) {
                 template.copy(
                     savedInstanceState = bundles.getOrNull(it)
                 )

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/ConfigurationContext.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/ConfigurationContext.kt
@@ -3,6 +3,7 @@ package com.badoo.ribs.core.routing.configuration
 import android.os.Bundle
 import android.os.Parcelable
 import com.badoo.ribs.core.Node
+import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.routing.action.RoutingAction
 import com.badoo.ribs.core.routing.configuration.ConfigurationContext.ActivationState.ACTIVE
 import com.badoo.ribs.core.routing.portal.AncestryInfo
@@ -108,11 +109,15 @@ internal sealed class ConfigurationContext<C : Parcelable> {
 
         private fun buildNodes(routingAction: RoutingAction, parentNode: Node<*>): List<Node<*>> =
             routingAction.buildNodes(
-                ancestryInfo = AncestryInfo.Child(
-                    anchor = routingAction.anchor() ?: parentNode,
-                    creatorConfiguration = configuration
-                ),
-                bundles = bundles
+                buildContexts = bundles.map {
+                    BuildContext(
+                        ancestryInfo = AncestryInfo.Child(
+                            anchor = routingAction.anchor() ?: parentNode,
+                            creatorConfiguration = configuration
+                        ),
+                        savedInstanceState = it
+                    )
+                }
             )
 
         override fun withActivationState(activationState: ActivationState) =

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/ConfigurationContext.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/ConfigurationContext.kt
@@ -7,6 +7,7 @@ import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.routing.action.RoutingAction
 import com.badoo.ribs.core.routing.configuration.ConfigurationContext.ActivationState.ACTIVE
 import com.badoo.ribs.core.routing.portal.AncestryInfo
+import com.badoo.ribs.util.RIBs
 import kotlinx.android.parcel.Parcelize
 
 /**
@@ -108,6 +109,11 @@ internal sealed class ConfigurationContext<C : Parcelable> {
             this
 
         private fun buildNodes(routingAction: RoutingAction, parentNode: Node<*>): List<Node<*>> {
+            if (bundles.isNotEmpty() && bundles.size != routingAction.nbNodesToBuild) {
+                RIBs.errorHandler.handleNonFatalError(
+                    "Bundles size ${bundles.size} don't match expected nodes count ${routingAction.nbNodesToBuild}"
+                )
+            }
             val template = createBuildContext(routingAction, parentNode)
             val buildContexts = List(routingAction.nbNodesToBuild) {
                 template.copy(

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/ConfigurationContext.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/configuration/ConfigurationContext.kt
@@ -107,18 +107,29 @@ internal sealed class ConfigurationContext<C : Parcelable> {
         override fun shrink(): Unresolved<C> =
             this
 
-        private fun buildNodes(routingAction: RoutingAction, parentNode: Node<*>): List<Node<*>> =
-            routingAction.buildNodes(
-                buildContexts = bundles.map {
-                    BuildContext(
-                        ancestryInfo = AncestryInfo.Child(
-                            anchor = routingAction.anchor() ?: parentNode,
-                            creatorConfiguration = configuration
-                        ),
-                        savedInstanceState = it
-                    )
-                }
+        private fun buildNodes(routingAction: RoutingAction, parentNode: Node<*>): List<Node<*>> {
+            val template = createBuildContext(routingAction, parentNode)
+            val buildContexts = MutableList(routingAction.nbNodesToBuild) {
+                template.copy(
+                    savedInstanceState = bundles.getOrNull(it)
+                )
+            }
+
+            return routingAction.buildNodes(
+                buildContexts = buildContexts
             )
+        }
+
+        private fun createBuildContext(
+            routingAction: RoutingAction,
+            parentNode: Node<*>
+        ): BuildContext = BuildContext(
+            ancestryInfo = AncestryInfo.Child(
+                anchor = routingAction.anchor() ?: parentNode,
+                creatorConfiguration = configuration
+            ),
+            savedInstanceState = null
+        )
 
         override fun withActivationState(activationState: ActivationState) =
             copy(

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/portal/PortalRouter.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/routing/portal/PortalRouter.kt
@@ -3,6 +3,7 @@ package com.badoo.ribs.core.routing.portal
 import android.os.Bundle
 import android.os.Parcelable
 import com.badoo.ribs.core.Router
+import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.builder.BuildParams
 import com.badoo.ribs.core.routing.action.RoutingAction
 import com.badoo.ribs.core.routing.configuration.ConfigurationResolver
@@ -66,11 +67,15 @@ class PortalRouter(
             // TODO don't build it again if already available as child.
             //  This probably means storing Node identifier in addition to (Parcelable) configuration.
             val nodes = routingAction.buildNodes(
-                ancestryInfo = AncestryInfo.Root, // we'll be discarding these Nodes, it doesn't matter
-                // TODO for maximum correctness, original List<> should also contain Bundles,
-                //  as that might change how dependencies are built (right now there's no case for this,
-                //  but can be in the future).
-                bundles = emptyList()
+                listOf(
+                    BuildContext(
+                        ancestryInfo = AncestryInfo.Root, // we'll be discarding these Nodes, it doesn't matter
+                        // TODO for maximum correctness, original List<> should also contain Bundles,
+                        //  as that might change how dependencies are built (right now there's no case for this,
+                        //  but can be in the future).
+                        savedInstanceState = null
+                    )
+                )
             )
 
             // TODO having 0 nodes is an impossible scenario, but having more than 1 can be valid.

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/dialog/Dialog.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/dialog/Dialog.kt
@@ -73,9 +73,9 @@ abstract class Dialog<T : Any> private constructor(
         events.accept(event)
     }
 
-    fun buildNodes(ancestryInfo: AncestryInfo, bundles: List<Bundle?>): List<Node<*>> =
+    fun buildNodes(buildContext: BuildContext): List<Node<*>> =
         nodeFactory?.let { factory ->
-            val clientParams = BuildContext(
+            val clientParams = buildContext.copy(
                 /**
                  * RIBs inside dialogs behaved like Root nodes so far in that they were
                  * not added as a child of any other Node.
@@ -84,9 +84,7 @@ abstract class Dialog<T : Any> private constructor(
                  * A benefit of this would be back press and lifecycle propagation.
                  * Not entirely sure it is needed. To be reconsidered later.
                  */
-                ancestryInfo = ancestryInfo,
-                attachMode = AttachMode.EXTERNAL,
-                savedInstanceState = bundles.firstOrNull()
+                attachMode = AttachMode.EXTERNAL
             )
 
             listOf(

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/dialog/Dialog.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/dialog/Dialog.kt
@@ -1,12 +1,10 @@
 package com.badoo.ribs.dialog
 
-import android.os.Bundle
 import com.badoo.ribs.android.Text
 import com.badoo.ribs.core.AttachMode
 import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.builder.NodeFactory
-import com.badoo.ribs.core.routing.portal.AncestryInfo
 import com.badoo.ribs.dialog.Dialog.CancellationPolicy.NonCancellable
 import com.jakewharton.rxrelay2.PublishRelay
 import io.reactivex.ObservableSource

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/RouterTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/RouterTest.kt
@@ -36,7 +36,7 @@ class RouterTest {
         childNodeC2_1 = mock()
         childNodeC2_2 = mock()
 
-        routingActionForC2 = mock { on { buildNodes(any(), anyOrNull())} doReturn listOf(childNodeC2_1, childNodeC2_2) }
+        routingActionForC2 = mock { on { buildNodes(any())} doReturn listOf(childNodeC2_1, childNodeC2_2) }
         routingActionForC1 = mock()
         routingActionForC3 = mock()
         routingActionForC4 = mock()

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationContextTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationContextTest.kt
@@ -141,7 +141,7 @@ class ConfigurationContextTest {
             parentNode,
             parentNode,
             NB_EXPECTED_NODES,
-            MutableList(NB_EXPECTED_NODES) { mock<Bundle>() }
+            List(NB_EXPECTED_NODES) { mock<Bundle>() }
         )
     }
 
@@ -154,9 +154,9 @@ class ConfigurationContextTest {
         nbExpectedNodes: Int,
         bundles: List<Bundle>
     ) {
-        assertEquals("Expected empty list of bundles or exactly $nbExpectedNodes, actual: ${bundles.size}",
-            true, bundles.isEmpty() || bundles.size == nbExpectedNodes
-        )
+        assert(bundles.isEmpty() || bundles.size == nbExpectedNodes) {
+            "Expected empty list of bundles or exactly $nbExpectedNodes, actual: ${bundles.size}"
+        }
 
         val unresolved = Unresolved<Parcelable>(mock(), mock(), bundles)
         val resolved = unresolved.resolve(resolver, parentNode)

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationContextTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationContextTest.kt
@@ -2,6 +2,7 @@ package com.badoo.ribs.core.routing.configuration
 
 import android.os.Bundle
 import android.os.Parcelable
+import com.badoo.ribs.core.AttachMode
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.routing.action.RoutingAction
@@ -12,6 +13,7 @@ import com.badoo.ribs.core.routing.configuration.ConfigurationContext.Resolved
 import com.badoo.ribs.core.routing.configuration.ConfigurationContext.Unresolved
 import com.badoo.ribs.core.routing.portal.AncestryInfo
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -20,11 +22,15 @@ import org.junit.Test
 
 class ConfigurationContextTest {
 
+    companion object {
+        private const val NB_EXPECTED_NODES = 3
+    }
+
     private val nodes: List<Node<*>> = listOf(mock(), mock())
 
     // Default
     private val defaultRoutingAction = mock<RoutingAction> {
-        on { nbNodesToBuild } doReturn 1
+        on { nbNodesToBuild } doReturn NB_EXPECTED_NODES
         on { buildNodes(any()) } doReturn nodes
     }
     private val defaultResolver = mock<(Parcelable) -> RoutingAction> {
@@ -34,7 +40,7 @@ class ConfigurationContextTest {
     // With Anchor
     private val mockAnchor: Node<*> = mock()
     private val routingActionWithAnchor = mock<RoutingAction> {
-        on { nbNodesToBuild } doReturn 1
+        on { nbNodesToBuild } doReturn NB_EXPECTED_NODES
         on { buildNodes(any()) } doReturn nodes
         on { anchor() } doReturn mockAnchor
     }
@@ -103,34 +109,73 @@ class ConfigurationContextTest {
     @Test
     fun `Unresolved resolve() calls RoutingAction with parent as default anchor `() {
         val parentNode = mock<Node<*>>()
-        verifyBuildNodesCalled(defaultResolver, defaultRoutingAction, parentNode, parentNode)
+        verifyBuildNodesCalledCorrectly(
+            defaultResolver,
+            defaultRoutingAction,
+            parentNode,
+            parentNode,
+            NB_EXPECTED_NODES,
+            emptyList<Bundle>()
+        )
     }
 
     @Test
     fun `Unresolved resolve() calls RoutingAction with expected anchor`() {
         val parentNode = mock<Node<*>>()
-        verifyBuildNodesCalled(resolverWithAnchor, routingActionWithAnchor, mockAnchor, parentNode)
+        verifyBuildNodesCalledCorrectly(
+            resolverWithAnchor,
+            routingActionWithAnchor,
+            mockAnchor,
+            parentNode,
+            NB_EXPECTED_NODES,
+            emptyList<Bundle>()
+        )
     }
 
-    private fun verifyBuildNodesCalled(
+    @Test
+    fun `Unresolved resolve() calls RoutingAction with proper Bundles if there's any`() {
+        val parentNode = mock<Node<*>>()
+        verifyBuildNodesCalledCorrectly(
+            defaultResolver,
+            defaultRoutingAction,
+            parentNode,
+            parentNode,
+            NB_EXPECTED_NODES,
+            MutableList(NB_EXPECTED_NODES) { mock<Bundle>() }
+        )
+    }
+
+
+    private fun verifyBuildNodesCalledCorrectly(
         resolver: (Parcelable) -> RoutingAction,
         routingAction: RoutingAction,
         expectedParent: Node<*>,
-        parentNode: Node<*>
+        parentNode: Node<*>,
+        nbExpectedNodes: Int,
+        bundles: List<Bundle>
     ) {
-        val bundles = emptyList<Bundle>()
-        val unresolved = Unresolved<Parcelable>(mock(), mock())
+        assertEquals("Expected empty list of bundles or exactly $nbExpectedNodes, actual: ${bundles.size}",
+            true, bundles.isEmpty() || bundles.size == nbExpectedNodes
+        )
+
+        val unresolved = Unresolved<Parcelable>(mock(), mock(), bundles)
         val resolved = unresolved.resolve(resolver, parentNode)
         val expectedAncestryInfo = AncestryInfo.Child(expectedParent, resolved.configuration)
 
-        verify(routingAction).buildNodes(
-            listOf(
-                BuildContext(
-                    ancestryInfo = expectedAncestryInfo,
-                    savedInstanceState = null
-                )
-            )
-        )
+        argumentCaptor<List<BuildContext>>().apply {
+            verify(routingAction).buildNodes(capture())
+            val list = firstValue
+            assertEquals(nbExpectedNodes, list.size)
+
+            list.forEachIndexed { idx, buildContext ->
+                assertEquals(expectedAncestryInfo, buildContext.ancestryInfo)
+                assertEquals(AttachMode.PARENT, buildContext.attachMode)
+
+                if (bundles.isNotEmpty()) {
+                    assertEquals(bundles[idx], buildContext.savedInstanceState)
+                }
+            }
+        }
     }
 
     @Test

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationContextTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationContextTest.kt
@@ -93,7 +93,7 @@ class ConfigurationContextTest {
 
     @Test
     fun `Unresolved resolve() keeps bundles`() {
-        val bundles = listOf(mock<Bundle>())
+        val bundles = List(NB_EXPECTED_NODES) { mock<Bundle>() }
         val unresolved = Unresolved<Parcelable>(mock(), mock(), bundles)
         val resolved = unresolved.resolve(defaultResolver, mock())
         assertEquals(bundles, resolved.bundles)

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationFeatureTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationFeatureTest.kt
@@ -88,7 +88,7 @@ class ConfigurationFeatureTest {
                 }
                 val bundles = MutableList(nbNodes) { mock<Bundle>() }
                 val factories = nodes.toFactory()
-                val routingAction: RoutingAction = factories.toRoutingAction()
+                val routingAction: RoutingAction = factories.toRoutingAction(nbNodes)
 
                 return ConfigurationTestHelper(
                     configuration = configuration,
@@ -106,8 +106,9 @@ class ConfigurationFeatureTest {
                     }
                 }
 
-            private fun List<() -> Node<*>>.toRoutingAction(): RoutingAction =
+            private fun List<() -> Node<*>>.toRoutingAction(nbNodes: Int): RoutingAction =
                 mock {
+                    on { nbNodesToBuild } doReturn nbNodes
                     on { buildNodes(anyList()) } doAnswer {
                         this@toRoutingAction.map {
                             factory -> factory.invoke()

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationFeatureTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/configuration/ConfigurationFeatureTest.kt
@@ -27,7 +27,6 @@ import com.badoo.ribs.core.routing.configuration.Transaction.MultiConfigurationC
 import com.badoo.ribs.core.routing.configuration.Transaction.MultiConfigurationCommand.WakeUp
 import com.badoo.ribs.core.routing.configuration.feature.ConfigurationFeature
 import com.badoo.ribs.core.routing.configuration.feature.SavedState
-import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.clearInvocations
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
@@ -42,6 +41,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyList
 
 class ConfigurationFeatureTest {
 
@@ -108,7 +108,7 @@ class ConfigurationFeatureTest {
 
             private fun List<() -> Node<*>>.toRoutingAction(): RoutingAction =
                 mock {
-                    on { buildNodes(anyOrNull(), anyOrNull()) } doAnswer {
+                    on { buildNodes(anyList()) } doAnswer {
                         this@toRoutingAction.map {
                             factory -> factory.invoke()
                         }

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/portal/PortalRouterTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/routing/portal/PortalRouterTest.kt
@@ -3,6 +3,8 @@ package com.badoo.ribs.core.routing.portal
 import com.badoo.ribs.core.helper.TestNode
 import com.badoo.ribs.core.helper.TestRouter
 import com.badoo.ribs.core.Node
+import com.badoo.ribs.core.builder.BuildContext
+import com.badoo.ribs.core.builder.BuildContext.Companion.root
 import com.badoo.ribs.core.helper.testBuildParams
 import com.badoo.ribs.core.routing.action.AttachRibRoutingAction.Companion.attach
 import com.badoo.ribs.core.routing.portal.PortalRouter.Configuration.Content.Portal
@@ -44,7 +46,7 @@ class PortalRouterTest {
             )
         )
 
-        val builtNodes = remoteRoutingAction.buildNodes(AncestryInfo.Root, emptyList())
+        val builtNodes = remoteRoutingAction.buildNodes(listOf(root(null)))
         assertEquals(listOf(node3), builtNodes)
     }
 }

--- a/android/tutorials/tutorial2/src/main/java/com/badoo/ribs/tutorials/tutorial2/app/RootActivity.kt
+++ b/android/tutorials/tutorial2/src/main/java/com/badoo/ribs/tutorials/tutorial2/app/RootActivity.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import com.badoo.ribs.android.RibActivity
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.builder.BuildContext
+import com.badoo.ribs.core.builder.BuildContext.Companion.root
 import com.badoo.ribs.tutorials.tutorial2.R
 import com.badoo.ribs.tutorials.tutorial2.rib.greetings_container.GreetingsContainer
 import com.badoo.ribs.tutorials.tutorial2.rib.greetings_container.builder.GreetingsContainerBuilder
@@ -34,5 +35,9 @@ class RootActivity : RibActivity() {
                         }
                     }
             }
-        ).build(BuildContext.root(savedInstanceState = savedInstanceState))
+        ).build(
+            buildContext = root(
+                savedInstanceState = savedInstanceState
+            )
+        )
 }

--- a/android/tutorials/tutorial2/src/main/java/com/badoo/ribs/tutorials/tutorial2/app/RootActivity.kt
+++ b/android/tutorials/tutorial2/src/main/java/com/badoo/ribs/tutorials/tutorial2/app/RootActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.ViewGroup
 import com.badoo.ribs.android.RibActivity
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.builder.BuildContext
 import com.badoo.ribs.core.builder.BuildContext.Companion.root
 import com.badoo.ribs.tutorials.tutorial2.R
 import com.badoo.ribs.tutorials.tutorial2.rib.greetings_container.GreetingsContainer


### PR DESCRIPTION
1. Moves the responsibility of creating `BuildContext` object one level deeper from `RoutingAction`, down to `RoutingAction` invocation.
2. Adds contract that `RoutingAction` reports the number of `Node`s it intends to build. Framework guarantees to pass that many objects. (This same mechanism existed with `Bundle`s so far, only implicitly, and without test coverage that it does indeed work as expected).

First point will also make it easier to add customisation into `BuildContext` by framework as compared to individual `RoutingActions`, which shouldn't have to do anything with it.