### PR TITLE
Attaching a child node built with root BuildContext should raise an error.

### DIFF
--- a/android/app-example/src/test/java/com/badoo/ribs/example/rib/switcher/SwitcherWorkflowTest.kt
+++ b/android/app-example/src/test/java/com/badoo/ribs/example/rib/switcher/SwitcherWorkflowTest.kt
@@ -30,25 +30,20 @@ class SwitcherWorkflowTest {
 
     @Before
     fun setup() {
-
-        fun <N> withBuilder(
-                builder: (BuildContext) -> N
-        ): (InvocationOnMock) -> N = { answer -> builder(answer.getArgument(0)) }
-
         val helloWorldNodeBuilder = { buildContext: BuildContext ->
-            HelloWorldNode(mock(), mock(), mock(), BuildParams.EmptyChild(buildContext))
+            HelloWorldNode(mock(), mock(), mock(), buildContext.toBuildParams())
         }
         val fooBarNodeBuilder = { buildContext: BuildContext ->
-            FooBarNode(mock(), mock(), BuildParams.EmptyChild(buildContext), emptySet())
+            FooBarNode(mock(), mock(), buildContext.toBuildParams(), emptySet())
         }
         val node1Builder = { buildContext: BuildContext ->
-            Node<DialogExampleView>(BuildParams.EmptyChild(buildContext), mock(), mock(), mock(), mock())
+            Node<DialogExampleView>(buildContext.toBuildParams(), mock(), mock(), mock(), mock())
         }
         val node2Builder = { buildContext: BuildContext ->
-            Node<BlockerView>(BuildParams.EmptyChild(buildContext), mock(), mock(), mock(), mock())
+            Node<BlockerView>(buildContext.toBuildParams(), mock(), mock(), mock(), mock())
         }
         val node3Builder = { buildContext: BuildContext ->
-            MenuNode(BuildParams.EmptyChild(buildContext), mock(), mock())
+            MenuNode(buildContext.toBuildParams(), mock(), mock())
         }
 
         router = SwitcherRouter(
@@ -71,6 +66,16 @@ class SwitcherWorkflowTest {
             interactor = interactor
         ).also { it.onAttach() }
     }
+    
+    private fun <N> withBuilder(
+            builder: (BuildContext) -> N
+    ): (InvocationOnMock) -> N = { answer -> builder(answer.getArgument(0)) }
+
+    private fun BuildContext.toBuildParams(): BuildParams<Nothing?> =
+        BuildParams(
+            payload = null,
+            buildContext = this
+        )
 
     @Test
     fun `attachHelloWorld`() {

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/Node.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import com.badoo.ribs.core.Rib.Identifier
 import com.badoo.ribs.core.builder.BuildParams
+import com.badoo.ribs.core.exception.RootNodeAttachedAsChildException
 import com.badoo.ribs.core.routing.configuration.ConfigurationResolver
 import com.badoo.ribs.core.routing.portal.AncestryInfo
 import com.badoo.ribs.core.view.RibView
@@ -203,6 +204,7 @@ open class Node<V : RibView>(
      */
     @MainThread
     internal fun attachChildNode(child: Node<*>) {
+        verifyNotRoot(child)
         children.add(child)
 //        ribRefWatcher.logBreadcrumb(
 //            "ATTACHED", child.javaClass.simpleName, this.javaClass.simpleName
@@ -211,6 +213,16 @@ open class Node<V : RibView>(
         lifecycleManager.onAttachChild(child)
         child.onAttach()
         childrenAttachesRelay.accept(child)
+    }
+
+    private fun verifyNotRoot(child: Node<*>) {
+        if (child.ancestryInfo is AncestryInfo.Root) {
+            val message = "A node that is attached as a child should not have a root BuildContext."
+            RIBs.errorHandler.handleNonFatalError(
+                errorMessage = message,
+                throwable = RootNodeAttachedAsChildException(message = "$message. RIB: $this")
+            )
+        }
     }
 
     // FIXME internal + protected?

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildParams.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildParams.kt
@@ -26,14 +26,5 @@ class BuildParams<T>(
             payload = null,
             buildContext = BuildContext.root(null)
         )
-
-        /**
-         * Only for testing purposes. Don't use this in production code, otherwise all your Nodes
-         * will be considered children.
-         */
-        fun EmptyChild(buildContext: BuildContext) = BuildParams(
-            payload = null,
-            buildContext = buildContext
-        )
     }
 }

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildParams.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildParams.kt
@@ -1,11 +1,8 @@
 package com.badoo.ribs.core.builder
 
 import android.os.Bundle
-import com.badoo.ribs.core.AttachMode
-import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.Rib
 import com.badoo.ribs.core.Rib.Identifier.Companion.KEY_UUID
-import com.badoo.ribs.core.routing.portal.AncestryInfo
 import java.util.UUID
 
 

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildParams.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/builder/BuildParams.kt
@@ -1,8 +1,11 @@
 package com.badoo.ribs.core.builder
 
 import android.os.Bundle
+import com.badoo.ribs.core.AttachMode
+import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.Rib
 import com.badoo.ribs.core.Rib.Identifier.Companion.KEY_UUID
+import com.badoo.ribs.core.routing.portal.AncestryInfo
 import java.util.UUID
 
 
@@ -25,6 +28,15 @@ class BuildParams<T>(
         fun Empty() = BuildParams(
             payload = null,
             buildContext = BuildContext.root(null)
+        )
+
+        /**
+         * Only for testing purposes. Don't use this in production code, otherwise all your Nodes
+         * will be considered children.
+         */
+        fun EmptyChild(buildContext: BuildContext) = BuildParams(
+            payload = null,
+            buildContext = buildContext
         )
     }
 }

--- a/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/exception/RootNodeAttachedAsChildException.kt
+++ b/android/libraries/rib-base/src/main/java/com/badoo/ribs/core/exception/RootNodeAttachedAsChildException.kt
@@ -1,0 +1,3 @@
+package com.badoo.ribs.core.exception
+
+class RootNodeAttachedAsChildException(message: String) : IllegalArgumentException(message)

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/LifecycleManagerTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/LifecycleManagerTest.kt
@@ -1,7 +1,10 @@
 package com.badoo.ribs.core
 
 import androidx.lifecycle.Lifecycle.State.RESUMED
+import com.badoo.ribs.core.helper.AnyConfiguration
 import com.badoo.ribs.core.helper.TestNode
+import com.badoo.ribs.core.helper.testBuildParams
+import com.badoo.ribs.core.routing.portal.AncestryInfo
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertEquals
@@ -41,7 +44,9 @@ class LifecycleManagerTest {
 
     @Test
     fun `onAttachChild() lifecycle inheritance is recursive`() {
-        val grandChild: Node<*> = TestNode()
+        val grandChildAncestryInfo = AncestryInfo.Child(child1, AnyConfiguration)
+        val grandChild: Node<*> =
+                TestNode(buildParams = testBuildParams(ancestryInfo = grandChildAncestryInfo))
         child1.attachChildNode(grandChild)
 
         val expected = RESUMED

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
@@ -8,12 +8,14 @@ import com.badoo.mvicore.android.lifecycle.createDestroy
 import com.badoo.ribs.core.Node.Companion.BUNDLE_KEY
 import com.badoo.ribs.core.Node.Companion.KEY_VIEW_STATE
 import com.badoo.ribs.core.builder.BuildParams
+import com.badoo.ribs.core.exception.RootNodeAttachedAsChildException
 import com.badoo.ribs.core.helper.TestInteractor
 import com.badoo.ribs.core.helper.TestNode
 import com.badoo.ribs.core.helper.TestNode2
 import com.badoo.ribs.core.helper.TestRouter
 import com.badoo.ribs.core.helper.TestView
 import com.badoo.ribs.core.helper.testBuildParams
+import com.badoo.ribs.core.routing.portal.AncestryInfo
 import com.badoo.ribs.core.view.ViewPlugin
 import com.badoo.ribs.util.RIBs
 import com.jakewharton.rxrelay2.PublishRelay
@@ -42,6 +44,7 @@ class NodeTest {
     interface RandomOtherNode1 : Rib
     interface RandomOtherNode2 : Rib
     interface RandomOtherNode3 : Rib
+    interface RandomRootNode : Rib
 
     interface TestViewFactory : (ViewGroup) -> TestView
 
@@ -58,8 +61,10 @@ class NodeTest {
     private lateinit var child1: TestNode
     private lateinit var child2: TestNode
     private lateinit var child3: TestNode
+    private lateinit var root1: TestNode
     private lateinit var allChildren: List<Node<*>>
     private lateinit var viewPlugins: Set<ViewPlugin>
+    private lateinit var childAncestry: AncestryInfo
 
     @Before
     fun setUp() {
@@ -74,8 +79,13 @@ class NodeTest {
         interactor = mock()
         viewPlugins = setOf(mock(), mock())
         node = createNode(viewFactory = viewFactory)
+        childAncestry = AncestryInfo.Child(node, TestRouter.Configuration.C1)
 
         addChildren()
+        root1 = TestNode(
+            buildParams = testBuildParams(object : RandomRootNode {}),
+            viewFactory = null
+        )
     }
 
     private fun createNode(
@@ -96,9 +106,27 @@ class NodeTest {
     }
 
     private fun addChildren() {
-        child1 = TestNode(testBuildParams(object : RandomOtherNode1 {}), viewFactory = null)
-        child2 = TestNode(testBuildParams(object : RandomOtherNode2 {}), viewFactory = null)
-        child3 = TestNode(testBuildParams(object : RandomOtherNode3 {}), viewFactory = null)
+        child1 = TestNode(
+            buildParams = testBuildParams(
+                rib = object : RandomOtherNode1 {},
+                ancestryInfo = childAncestry
+            ),
+            viewFactory = null
+        )
+        child2 = TestNode(
+            buildParams = testBuildParams(
+                rib = object : RandomOtherNode2 {},
+                ancestryInfo = childAncestry
+            ),
+            viewFactory = null
+        )
+        child3 = TestNode(
+            buildParams = testBuildParams(
+                rib = object : RandomOtherNode3 {},
+                ancestryInfo = childAncestry
+            ),
+            viewFactory = null
+        )
         allChildren = listOf(child1, child2, child3)
         node.children.addAll(allChildren)
     }
@@ -416,7 +444,8 @@ class NodeTest {
     fun `attachChildNode() does not imply attachToView when Android view system is not available`() {
         val childViewFactory = mock<TestViewFactory>()
         val child = TestNode(
-            viewFactory = childViewFactory
+            viewFactory = childViewFactory,
+            buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         node.attachChildNode(child)
         verify(childViewFactory, never()).invoke(parentViewGroup)
@@ -433,7 +462,8 @@ class NodeTest {
         // by default it's not started, should be on INITIALIZED
 
         val child = TestNode(
-            viewFactory = mock<TestViewFactory>()
+            viewFactory = mock<TestViewFactory>(),
+            buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         node.attachChildNode(child)
 
@@ -445,10 +475,14 @@ class NodeTest {
         // by default it's not started, should be on INITIALIZED
 
         val directChild = TestNode(
-            viewFactory = mock<TestViewFactory>()
+                viewFactory = mock<TestViewFactory>(),
+                buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
+        val grandChildAncestryInfo: AncestryInfo =
+                AncestryInfo.Child(directChild, TestRouter.Configuration.C1)
         val grandChild = TestNode(
-            viewFactory = mock<TestViewFactory>()
+                viewFactory = mock<TestViewFactory>(),
+                buildParams = testBuildParams(ancestryInfo = grandChildAncestryInfo)
         )
         directChild.attachChildNode(grandChild)
         node.attachChildNode(directChild)
@@ -461,7 +495,8 @@ class NodeTest {
         node.onStop()
 
         val child = TestNode(
-            viewFactory = mock<TestViewFactory>()
+            viewFactory = mock<TestViewFactory>(),
+            buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         node.attachChildNode(child)
 
@@ -473,10 +508,14 @@ class NodeTest {
         node.onStop()
 
         val directChild = TestNode(
-            viewFactory = mock<TestViewFactory>()
+            viewFactory = mock<TestViewFactory>(),
+            buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
+        val grandChildAncestryInfo: AncestryInfo =
+                AncestryInfo.Child(directChild, TestRouter.Configuration.C1)
         val grandChild = TestNode(
-            viewFactory = mock<TestViewFactory>()
+            viewFactory = mock<TestViewFactory>(),
+            buildParams = testBuildParams(ancestryInfo = grandChildAncestryInfo)
         )
         directChild.attachChildNode(grandChild)
         node.attachChildNode(directChild)
@@ -489,7 +528,8 @@ class NodeTest {
         node.onStart()
 
         val child = TestNode(
-            viewFactory = mock<TestViewFactory>()
+            viewFactory = mock<TestViewFactory>(),
+            buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         node.attachChildNode(child)
 
@@ -501,10 +541,12 @@ class NodeTest {
         node.onStart()
 
         val directChild = TestNode(
-            viewFactory = mock<TestViewFactory>()
+            viewFactory = mock<TestViewFactory>(),
+            buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         val grandChild = TestNode(
-            viewFactory = mock<TestViewFactory>()
+            viewFactory = mock<TestViewFactory>(),
+            buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         directChild.attachChildNode(grandChild)
         node.attachChildNode(directChild)
@@ -517,7 +559,8 @@ class NodeTest {
         node.onResume()
 
         val child = TestNode(
-            viewFactory = mock<TestViewFactory>()
+            viewFactory = mock<TestViewFactory>(),
+            buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         node.attachChildNode(child)
 
@@ -529,10 +572,14 @@ class NodeTest {
         node.onResume()
 
         val directChild = TestNode(
-            viewFactory = mock<TestViewFactory>()
+            viewFactory = mock<TestViewFactory>(),
+            buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
+        val grandChildAncestryInfo: AncestryInfo =
+                AncestryInfo.Child(directChild, TestRouter.Configuration.C1)
         val grandChild = TestNode(
-            viewFactory = mock<TestViewFactory>()
+                viewFactory = mock<TestViewFactory>(),
+                buildParams = testBuildParams(ancestryInfo = grandChildAncestryInfo)
         )
         directChild.attachChildNode(grandChild)
         node.attachChildNode(directChild)
@@ -754,7 +801,7 @@ class NodeTest {
     fun `waitForChildAttached emits expected child immediately if it's already attached`() {
         val workflow: Single<TestNode2> = node.waitForChildAttachedInternal()
         val testObserver = TestObserver<TestNode2>()
-        val testChildNode = TestNode2()
+        val testChildNode = TestNode2(buildParams = testBuildParams(ancestryInfo = childAncestry))
 
         node.attachChildNode(testChildNode)
         workflow.subscribe(testObserver)
@@ -773,5 +820,19 @@ class NodeTest {
 
         testObserver.assertNoValues()
         testObserver.assertNotComplete()
+    }
+
+    @Test
+    fun `When a child node has a root BuildContext, attachToView() invokes error handler`() {
+        node = createNode(viewFactory = null)
+        node.attachToView(parentViewGroup)
+
+        val errorHandler = mock<RIBs.ErrorHandler>()
+        RIBs.clearErrorHandler()
+        RIBs.errorHandler = errorHandler
+
+        node.attachChildNode(root1)
+
+        verify(errorHandler).handleNonFatalError(any(), isA<RootNodeAttachedAsChildException>())
     }
 }

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
@@ -9,6 +9,7 @@ import com.badoo.ribs.core.Node.Companion.BUNDLE_KEY
 import com.badoo.ribs.core.Node.Companion.KEY_VIEW_STATE
 import com.badoo.ribs.core.builder.BuildParams
 import com.badoo.ribs.core.exception.RootNodeAttachedAsChildException
+import com.badoo.ribs.core.helper.AnyConfiguration
 import com.badoo.ribs.core.helper.TestInteractor
 import com.badoo.ribs.core.helper.TestNode
 import com.badoo.ribs.core.helper.TestNode2
@@ -79,7 +80,7 @@ class NodeTest {
         interactor = mock()
         viewPlugins = setOf(mock(), mock())
         node = createNode(viewFactory = viewFactory)
-        childAncestry = AncestryInfo.Child(node, TestRouter.Configuration.C1)
+        childAncestry = AncestryInfo.Child(node, AnyConfiguration)
 
         addChildren()
         root1 = TestNode(
@@ -479,7 +480,7 @@ class NodeTest {
                 buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         val grandChildAncestryInfo: AncestryInfo =
-                AncestryInfo.Child(directChild, TestRouter.Configuration.C1)
+                AncestryInfo.Child(directChild, AnyConfiguration)
         val grandChild = TestNode(
                 viewFactory = mock<TestViewFactory>(),
                 buildParams = testBuildParams(ancestryInfo = grandChildAncestryInfo)
@@ -512,7 +513,7 @@ class NodeTest {
             buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         val grandChildAncestryInfo: AncestryInfo =
-                AncestryInfo.Child(directChild, TestRouter.Configuration.C1)
+                AncestryInfo.Child(directChild, AnyConfiguration)
         val grandChild = TestNode(
             viewFactory = mock<TestViewFactory>(),
             buildParams = testBuildParams(ancestryInfo = grandChildAncestryInfo)
@@ -576,7 +577,7 @@ class NodeTest {
             buildParams = testBuildParams(ancestryInfo = childAncestry)
         )
         val grandChildAncestryInfo: AncestryInfo =
-                AncestryInfo.Child(directChild, TestRouter.Configuration.C1)
+                AncestryInfo.Child(directChild, AnyConfiguration)
         val grandChild = TestNode(
                 viewFactory = mock<TestViewFactory>(),
                 buildParams = testBuildParams(ancestryInfo = grandChildAncestryInfo)

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodeTest.kt
@@ -20,14 +20,7 @@ import com.badoo.ribs.core.routing.portal.AncestryInfo
 import com.badoo.ribs.core.view.ViewPlugin
 import com.badoo.ribs.util.RIBs
 import com.jakewharton.rxrelay2.PublishRelay
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.anyOrNull
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.isA
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
 import io.reactivex.Single
 import io.reactivex.functions.Consumer
 import io.reactivex.observers.TestObserver
@@ -824,7 +817,7 @@ class NodeTest {
     }
 
     @Test
-    fun `When a child node has a root BuildContext, attachToView() invokes error handler`() {
+    fun `When a child node has a root BuildContext, attachChildNode() invokes error handler`() {
         node = createNode(viewFactory = null)
         node.attachToView(parentViewGroup)
 
@@ -835,5 +828,20 @@ class NodeTest {
         node.attachChildNode(root1)
 
         verify(errorHandler).handleNonFatalError(any(), isA<RootNodeAttachedAsChildException>())
+    }
+
+    @Test
+    fun `When a child node has a child BuildContext, attachChildNode() does not invoke any error`() {
+        node = createNode(viewFactory = null)
+        node.attachToView(parentViewGroup)
+
+        val errorHandler = mock<RIBs.ErrorHandler>()
+        RIBs.clearErrorHandler()
+        RIBs.errorHandler = errorHandler
+
+        node.attachChildNode(child1)
+
+        verify(errorHandler, never()).handleNonFatalError(any(), isA<RootNodeAttachedAsChildException>())
+        verifyNoMoreInteractions(errorHandler)
     }
 }

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/AnyConfiguration.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/AnyConfiguration.kt
@@ -1,0 +1,7 @@
+package com.badoo.ribs.core.helper
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+object AnyConfiguration : Parcelable { override fun toString(): String = "AnyConfiguration" }

--- a/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestBuildParams.kt
+++ b/android/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestBuildParams.kt
@@ -10,14 +10,19 @@ import java.util.UUID
 
 fun testBuildParams(
     rib: Rib = object : TestPublicRibInterface {},
-    savedInstanceState: Bundle? = null
+    savedInstanceState: Bundle? = null,
+    ancestryInfo: AncestryInfo? = null
 ) = BuildParams<Nothing?>(
     payload = null,
-    buildContext = BuildContext(
-        ancestryInfo = AncestryInfo.Root,
-        attachMode = AttachMode.PARENT,
-        savedInstanceState = savedInstanceState
-    ),
+    buildContext = if (ancestryInfo == null) {
+        BuildContext.root(savedInstanceState)
+    } else {
+        BuildContext(
+            ancestryInfo = ancestryInfo,
+            attachMode = AttachMode.PARENT,
+            savedInstanceState = savedInstanceState
+        )
+    },
     identifier = Rib.Identifier(
         uuid = UUID.randomUUID()
     )


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: When a node tries to attach another child node, if the child node is built with a Root BuildContext, we should raise a non-fatal error as this is a client-side misconfiguration (Root BuildContext should be used at actual roots at integration point).

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: #159 

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
