### PR TITLE
Set JVM 1.8 target for Kotlin

### DIFF
--- a/app-example/build.gradle
+++ b/app-example/build.gradle
@@ -1,8 +1,5 @@
 configureAndroidApp(project)
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-
 def getAccessToken() {
     def systemEnvKey = System.getenv('ACCESS_KEY')
 

--- a/gradle/utils.gradle
+++ b/gradle/utils.gradle
@@ -1,10 +1,13 @@
 ext.configureAndroidLibrary = { project ->
     project.apply plugin: 'com.android.library'
+    project.apply plugin: 'kotlin-android'
     configureAndroidModule(project)
 }
 
 ext.configureAndroidApp = { project ->
     project.apply plugin: 'com.android.application'
+    project.apply plugin: 'kotlin-android'
+    project.apply plugin: 'kotlin-android-extensions'
     configureAndroidModule(project)
 }
 
@@ -25,6 +28,10 @@ private def configureAndroidModule(Project project) {
         }
 
         testOptions.unitTests.includeAndroidResources = true
+
+        project.afterEvaluate {
+            project.android.kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
+        }
     }
 }
 

--- a/libraries/rib-base-test-activity/build.gradle
+++ b/libraries/rib-base-test-activity/build.gradle
@@ -1,9 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-
 android {
     defaultConfig {
         versionCode 1

--- a/libraries/rib-base-test/build.gradle
+++ b/libraries/rib-base-test/build.gradle
@@ -1,9 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-
 android {
     defaultConfig {
         versionCode 1

--- a/libraries/rib-base/build.gradle
+++ b/libraries/rib-base/build.gradle
@@ -1,6 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 androidExtensions {

--- a/libraries/rib-compose/build.gradle
+++ b/libraries/rib-compose/build.gradle
@@ -1,6 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 androidExtensions {

--- a/libraries/rib-debug-utils/build.gradle
+++ b/libraries/rib-debug-utils/build.gradle
@@ -1,7 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
-
 dependencies {
     implementation project(":libraries:rib-base")
     implementation deps.external.kotlinStdlib

--- a/libraries/rib-portal-rx/build.gradle
+++ b/libraries/rib-portal-rx/build.gradle
@@ -1,6 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 androidExtensions {

--- a/libraries/rib-portal/build.gradle
+++ b/libraries/rib-portal/build.gradle
@@ -1,6 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 androidExtensions {

--- a/libraries/rib-recyclerview/build.gradle
+++ b/libraries/rib-recyclerview/build.gradle
@@ -1,6 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 androidExtensions {

--- a/libraries/rib-rx/build.gradle
+++ b/libraries/rib-rx/build.gradle
@@ -1,6 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 androidExtensions {

--- a/sandbox-compose-placeholder/build.gradle
+++ b/sandbox-compose-placeholder/build.gradle
@@ -1,6 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {

--- a/sandbox-compose/build.gradle
+++ b/sandbox-compose/build.gradle
@@ -1,6 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -1,7 +1,5 @@
 configureAndroidApp(project)
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/tutorials/tutorial1/build.gradle
+++ b/tutorials/tutorial1/build.gradle
@@ -1,7 +1,5 @@
 configureAndroidApp(project)
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/tutorials/tutorial2/build.gradle
+++ b/tutorials/tutorial2/build.gradle
@@ -1,7 +1,5 @@
 configureAndroidApp(project)
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/tutorials/tutorial3/build.gradle
+++ b/tutorials/tutorial3/build.gradle
@@ -1,7 +1,5 @@
 configureAndroidApp(project)
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/tutorials/tutorial4/build.gradle
+++ b/tutorials/tutorial4/build.gradle
@@ -1,7 +1,5 @@
 configureAndroidApp(project)
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/tutorials/tutorial5/build.gradle
+++ b/tutorials/tutorial5/build.gradle
@@ -1,7 +1,5 @@
 configureAndroidApp(project)
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {


### PR DESCRIPTION
Kotlin compiler still uses 1.6 target, use 1.8 instead.
It allow us to use 1.8 compiled external dependencies (e.g. `androidx-ktx` libraries).