### PR TITLE
Expose get customisation by class method in the same way as getOrDefault

### DIFF
--- a/libraries/rib-base/src/main/java/com/badoo/ribs/core/modality/BuildParams.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/core/modality/BuildParams.kt
@@ -6,6 +6,7 @@ import com.badoo.ribs.core.Rib.Identifier.Companion.KEY_UUID
 import com.badoo.ribs.core.customisation.RibCustomisation
 import com.badoo.ribs.core.customisation.RibCustomisationDirectoryImpl
 import java.util.UUID
+import kotlin.reflect.KClass
 
 
 /**
@@ -40,7 +41,10 @@ class BuildParams<T>(
         )
     }
 
-    fun <T : RibCustomisation> getOrDefault(defaultCustomisation: T) : T =
+    fun <T : RibCustomisation> get(key: KClass<T>): T? =
+        buildContext.customisations.getRecursively(key)
+
+    fun <T : RibCustomisation> getOrDefault(defaultCustomisation: T): T =
         buildContext.customisations.getRecursivelyOrDefault(defaultCustomisation)
 
 }


### PR DESCRIPTION
Dynamic Delivery implementation requires to have customisation as an interface and not as an actual class.
The framework checks the keys for customisations by equality and not by inheritability. That is why it is not possible to use interface class key to receive interface implementation object.
BuildParams exposes only `getOrDefault`, so I decided to expose `get` method too.

Current implementation:
```kotlin
buildParams.buildContext.customisations.getRecursively(Brew.Customisation::class) ?: BrewCustomisation()
```

 