### PR TITLE
Add theme to dialogs

### DIFF
--- a/libraries/rib-base/src/main/java/com/badoo/ribs/android/dialog/Dialog.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/android/dialog/Dialog.kt
@@ -1,5 +1,6 @@
 package com.badoo.ribs.android.dialog
 
+import androidx.annotation.StyleRes
 import com.badoo.ribs.android.dialog.Dialog.CancellationPolicy.NonCancellable
 import com.badoo.ribs.android.text.Text
 import com.badoo.ribs.core.Rib
@@ -15,6 +16,8 @@ abstract class Dialog<T : Any> private constructor(
     var title: Text? = null
     var message: Text? = null
     var cancellationPolicy: CancellationPolicy<T> = NonCancellable()
+    @StyleRes
+    var themeResId: Int? = null
     var buttons: ButtonsConfig<T>? = null
     private var ribFactory: RibFactory? = null
     internal var rib: Rib? = null

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/android/dialog/DialogExtensions.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/android/dialog/DialogExtensions.kt
@@ -7,19 +7,23 @@ import com.badoo.ribs.android.AndroidRibViewHost
 import com.badoo.ribs.android.dialog.Dialog.CancellationPolicy.Cancellable
 import com.badoo.ribs.android.dialog.Dialog.CancellationPolicy.NonCancellable
 
-fun <Event : Any> Dialog<Event>.toAlertDialog(context: Context, onClose: () -> Unit) : AlertDialog =
-    AlertDialog.Builder(context)
-        .apply {
-            setCancelable(this@toAlertDialog, onClose)
-            setRib(this@toAlertDialog, context)
-            setTexts(this@toAlertDialog)
-            setButtons(this@toAlertDialog)
-        }
-        .create()
-        .apply {
-            setCanceledOnTouchOutside(this@toAlertDialog)
-            setButtonClickListeners(this@toAlertDialog, onClose)
-        }
+fun <Event : Any> Dialog<Event>.toAlertDialog(context: Context, onClose: () -> Unit): AlertDialog {
+    val builder = themeResId?.let { AlertDialog.Builder(context, it) }
+            ?: AlertDialog.Builder(context)
+
+    return builder
+            .apply {
+                setCancelable(this@toAlertDialog, onClose)
+                setRib(this@toAlertDialog, context)
+                setTexts(this@toAlertDialog)
+                setButtons(this@toAlertDialog)
+            }
+            .create()
+            .apply {
+                setCanceledOnTouchOutside(this@toAlertDialog)
+                setButtonClickListeners(this@toAlertDialog, onClose)
+            }
+}
 
 private fun <Event : Any> AlertDialog.Builder.setCancelable(dialog: Dialog<Event>, onClose: () -> Unit) {
     when (val policy = dialog.cancellationPolicy) {

--- a/sandbox/detekt-baseline.xml
+++ b/sandbox/detekt-baseline.xml
@@ -28,9 +28,6 @@
     <ID>FunctionNaming:MenuViewTest.kt$MenuViewTest$@Test fun viewModelWithSelectedItem_selectsItem()</ID>
     <ID>LibraryCodeMustSpecifyReturnType:BigChildBuilders.kt$BigChildBuilders$val small = SmallBuilder(subtreeDeps)</ID>
     <ID>LibraryCodeMustSpecifyReturnType:DialogExampleChildBuilders.kt$DialogExampleChildBuilders$val loremIpsum = LoremIpsumBuilder(subtreeDeps)</ID>
-    <ID>LibraryCodeMustSpecifyReturnType:Dialogs.kt$Dialogs$val lazyDialog = LazyDialog()</ID>
-    <ID>LibraryCodeMustSpecifyReturnType:Dialogs.kt$Dialogs$val ribDialog = RibDialog( builders.loremIpsum )</ID>
-    <ID>LibraryCodeMustSpecifyReturnType:Dialogs.kt$Dialogs$val simpleDialog = SimpleDialog()</ID>
     <ID>LibraryCodeMustSpecifyReturnType:HelloWorldChildBuilders.kt$HelloWorldChildBuilders$val small = SmallBuilder(subtreeDeps)</ID>
     <ID>LibraryCodeMustSpecifyReturnType:OtherActivity.kt$OtherActivity.Companion$const val KEY_INCOMING = "incoming"</ID>
     <ID>LibraryCodeMustSpecifyReturnType:OtherActivity.kt$OtherActivity.Companion$const val KEY_RETURNED_DATA = "foo"</ID>

--- a/sandbox/src/androidTest/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleTest.kt
+++ b/sandbox/src/androidTest/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleTest.kt
@@ -1,12 +1,22 @@
 package com.badoo.ribs.sandbox.rib.dialog_example
 
 import android.os.Bundle
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.badoo.common.ribs.RibsRule
 import com.badoo.ribs.RibTestActivity
 import com.badoo.ribs.android.dialog.DialogLauncher
 import com.badoo.ribs.core.modality.BuildContext.Companion.root
+import com.badoo.ribs.sandbox.R
+import com.badoo.ribs.sandbox.matcher.withTextColor
 import org.junit.Rule
 import org.junit.Test
+
 
 class DialogExampleTest {
 
@@ -19,6 +29,53 @@ class DialogExampleTest {
         }).build(root(savedInstanceState))
 
     @Test
-    fun testSomething() {
+    fun showsSimpleDialog() {
+        onView(withId(R.id.show_simple_dialog)).perform(click())
+
+        onView(withText(R.string.show_simple_dialog))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
     }
+
+    @Test
+    fun showsThemedDialog() {
+        onView(withId(R.id.show_themed_dialog)).perform(click())
+
+        onView(withText(R.string.show_themed_dialog))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        // Positive button
+        onView(withId(android.R.id.button1))
+            .inRoot(isDialog())
+            .check(matches(withTextColor(R.color.blue)))
+
+        // Negative button
+        onView(withId(android.R.id.button2))
+            .inRoot(isDialog())
+            .check(matches(withTextColor(R.color.red)))
+    }
+
+    @Test
+    fun showsRibDialog() {
+        onView(withId(R.id.show_rib_dialog)).perform(click())
+
+        onView(withText(R.string.a_title_you_wish))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.lorem_ipsum_button))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun showsLazyDialog() {
+        onView(withId(R.id.show_lazy_dialog)).perform(click())
+
+        onView(withText(R.string.lazy_dialog_title))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+    }
+
 }

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleInteractor.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleInteractor.kt
@@ -13,7 +13,7 @@ import com.badoo.ribs.routing.source.backstack.operation.pushOverlay
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowLazyDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowRibDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowSimpleDialogClicked
-import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowThemeDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowThemedDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.ViewModel
 import com.badoo.ribs.sandbox.rib.dialog_example.dialog.Dialogs
 import com.badoo.ribs.sandbox.rib.dialog_example.routing.DialogExampleRouter.Configuration
@@ -39,7 +39,7 @@ class DialogExampleInteractor internal constructor(
         viewLifecycle.startStop {
             bind(dummyViewInput to view)
             bind(view to viewEventConsumer)
-            bind(dialogs.themeDialog to dialogEventConsumer)
+            bind(dialogs.themedDialog to dialogEventConsumer)
             bind(dialogs.simpleDialog to dialogEventConsumer)
             bind(dialogs.lazyDialog to dialogEventConsumer)
             bind(dialogs.ribDialog to dialogEventConsumer)
@@ -56,7 +56,7 @@ class DialogExampleInteractor internal constructor(
 
     private val viewEventConsumer: Consumer<DialogExampleView.Event> = Consumer {
         when (it) {
-            ShowThemeDialogClicked -> backStack.pushOverlay(Overlay.ThemeDialog)
+            ShowThemedDialogClicked -> backStack.pushOverlay(Overlay.ThemedDialog)
             ShowSimpleDialogClicked -> backStack.pushOverlay(Overlay.SimpleDialog)
             ShowLazyDialogClicked -> {
                 initLazyDialog()

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleInteractor.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleInteractor.kt
@@ -10,7 +10,10 @@ import com.badoo.ribs.clienthelper.interactor.BackStackInteractor
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.modality.BuildParams
 import com.badoo.ribs.routing.source.backstack.operation.pushOverlay
-import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.*
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowLazyDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowRibDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowSimpleDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowThemeDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.ViewModel
 import com.badoo.ribs.sandbox.rib.dialog_example.dialog.Dialogs
 import com.badoo.ribs.sandbox.rib.dialog_example.routing.DialogExampleRouter.Configuration
@@ -55,7 +58,7 @@ class DialogExampleInteractor internal constructor(
         when (it) {
             ShowThemeDialogClicked -> backStack.pushOverlay(Overlay.ThemeDialog)
             ShowSimpleDialogClicked -> backStack.pushOverlay(Overlay.SimpleDialog)
-            ShowLazyDialog -> {
+            ShowLazyDialogClicked -> {
                 initLazyDialog()
                 backStack.pushOverlay(Overlay.LazyDialog)
             }

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleInteractor.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleInteractor.kt
@@ -10,9 +10,7 @@ import com.badoo.ribs.clienthelper.interactor.BackStackInteractor
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.modality.BuildParams
 import com.badoo.ribs.routing.source.backstack.operation.pushOverlay
-import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowLazyDialog
-import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowRibDialogClicked
-import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowSimpleDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.*
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.ViewModel
 import com.badoo.ribs.sandbox.rib.dialog_example.dialog.Dialogs
 import com.badoo.ribs.sandbox.rib.dialog_example.routing.DialogExampleRouter.Configuration
@@ -38,6 +36,7 @@ class DialogExampleInteractor internal constructor(
         viewLifecycle.startStop {
             bind(dummyViewInput to view)
             bind(view to viewEventConsumer)
+            bind(dialogs.themeDialog to dialogEventConsumer)
             bind(dialogs.simpleDialog to dialogEventConsumer)
             bind(dialogs.lazyDialog to dialogEventConsumer)
             bind(dialogs.ribDialog to dialogEventConsumer)
@@ -54,6 +53,7 @@ class DialogExampleInteractor internal constructor(
 
     private val viewEventConsumer: Consumer<DialogExampleView.Event> = Consumer {
         when (it) {
+            ShowThemeDialogClicked -> backStack.pushOverlay(Overlay.ThemeDialog)
             ShowSimpleDialogClicked -> backStack.pushOverlay(Overlay.SimpleDialog)
             ShowLazyDialog -> {
                 initLazyDialog()

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleInteractor.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleInteractor.kt
@@ -10,6 +10,7 @@ import com.badoo.ribs.clienthelper.interactor.BackStackInteractor
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.modality.BuildParams
 import com.badoo.ribs.routing.source.backstack.operation.pushOverlay
+import com.badoo.ribs.sandbox.R
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowLazyDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowRibDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowSimpleDialogClicked
@@ -69,7 +70,7 @@ class DialogExampleInteractor internal constructor(
 
     private fun initLazyDialog() {
         with(dialogs.lazyDialog) {
-            title = Text.Plain("Lazy dialog title")
+            title = Text.Resource(R.string.lazy_dialog_title)
             message = Text.Plain("Lazy dialog message")
             buttons {
                 neutral(Text.Plain("Lazy neutral button"), Dialog.Event.Neutral)

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleView.kt
@@ -10,7 +10,10 @@ import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.sandbox.R
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event
-import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.*
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowLazyDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowRibDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowSimpleDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowThemeDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.ViewModel
 import com.jakewharton.rxrelay2.PublishRelay
 import io.reactivex.ObservableSource
@@ -23,7 +26,7 @@ interface DialogExampleView : RibView,
     sealed class Event {
         object ShowThemeDialogClicked : Event()
         object ShowSimpleDialogClicked : Event()
-        object ShowLazyDialog : Event()
+        object ShowLazyDialogClicked : Event()
         object ShowRibDialogClicked : Event()
     }
 
@@ -61,7 +64,7 @@ class DialogExampleViewImpl  private constructor(
     init {
         showThemeDialog.setOnClickListener { events.accept(ShowThemeDialogClicked) }
         showSimpleDialog.setOnClickListener { events.accept(ShowSimpleDialogClicked) }
-        showLazyDialog.setOnClickListener { events.accept(ShowLazyDialog) }
+        showLazyDialog.setOnClickListener { events.accept(ShowLazyDialogClicked) }
         showRibDialog.setOnClickListener { events.accept(ShowRibDialogClicked) }
     }
 

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleView.kt
@@ -10,8 +10,7 @@ import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.sandbox.R
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event
-import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowRibDialogClicked
-import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowSimpleDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.*
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.ViewModel
 import com.jakewharton.rxrelay2.PublishRelay
 import io.reactivex.ObservableSource
@@ -22,6 +21,7 @@ interface DialogExampleView : RibView,
     Consumer<ViewModel> {
 
     sealed class Event {
+        object ShowThemeDialogClicked : Event()
         object ShowSimpleDialogClicked : Event()
         object ShowLazyDialog : Event()
         object ShowRibDialogClicked : Event()
@@ -52,14 +52,16 @@ class DialogExampleViewImpl  private constructor(
         }
     }
 
+    private val showThemeDialog: Button = androidView.findViewById(R.id.show_theme_dialog)
     private val showSimpleDialog: Button = androidView.findViewById(R.id.show_simple_dialog)
     private val showRibDialog: Button = androidView.findViewById(R.id.show_rib_dialog)
     private val showLazyDialog: Button = androidView.findViewById(R.id.show_lazy_dialog)
     private val text: TextView = androidView.findViewById(R.id.dialogs_example_debug)
 
     init {
+        showThemeDialog.setOnClickListener { events.accept(ShowThemeDialogClicked) }
         showSimpleDialog.setOnClickListener { events.accept(ShowSimpleDialogClicked) }
-        showLazyDialog.setOnClickListener { events.accept(Event.ShowLazyDialog) }
+        showLazyDialog.setOnClickListener { events.accept(ShowLazyDialog) }
         showRibDialog.setOnClickListener { events.accept(ShowRibDialogClicked) }
     }
 

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleView.kt
@@ -13,7 +13,7 @@ import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowLazyDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowRibDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowSimpleDialogClicked
-import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowThemeDialogClicked
+import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.Event.ShowThemedDialogClicked
 import com.badoo.ribs.sandbox.rib.dialog_example.DialogExampleView.ViewModel
 import com.jakewharton.rxrelay2.PublishRelay
 import io.reactivex.ObservableSource
@@ -24,7 +24,7 @@ interface DialogExampleView : RibView,
     Consumer<ViewModel> {
 
     sealed class Event {
-        object ShowThemeDialogClicked : Event()
+        object ShowThemedDialogClicked : Event()
         object ShowSimpleDialogClicked : Event()
         object ShowLazyDialogClicked : Event()
         object ShowRibDialogClicked : Event()
@@ -55,14 +55,14 @@ class DialogExampleViewImpl  private constructor(
         }
     }
 
-    private val showThemeDialog: Button = androidView.findViewById(R.id.show_theme_dialog)
     private val showSimpleDialog: Button = androidView.findViewById(R.id.show_simple_dialog)
+    private val showThemedDialog: Button = androidView.findViewById(R.id.show_themed_dialog)
     private val showRibDialog: Button = androidView.findViewById(R.id.show_rib_dialog)
     private val showLazyDialog: Button = androidView.findViewById(R.id.show_lazy_dialog)
     private val text: TextView = androidView.findViewById(R.id.dialogs_example_debug)
 
     init {
-        showThemeDialog.setOnClickListener { events.accept(ShowThemeDialogClicked) }
+        showThemedDialog.setOnClickListener { events.accept(ShowThemedDialogClicked) }
         showSimpleDialog.setOnClickListener { events.accept(ShowSimpleDialogClicked) }
         showLazyDialog.setOnClickListener { events.accept(ShowLazyDialogClicked) }
         showRibDialog.setOnClickListener { events.accept(ShowRibDialogClicked) }

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/Dialogs.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/Dialogs.kt
@@ -3,8 +3,9 @@ package com.badoo.ribs.sandbox.rib.dialog_example.dialog
 import com.badoo.ribs.sandbox.rib.dialog_example.routing.DialogExampleChildBuilders
 
 class Dialogs internal constructor(
-    private val builders: DialogExampleChildBuilders
+    builders: DialogExampleChildBuilders
 ) {
+    val themeDialog = ThemeDialog()
     val simpleDialog = SimpleDialog()
     val lazyDialog = LazyDialog()
     val ribDialog = RibDialog(

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/Dialogs.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/Dialogs.kt
@@ -1,14 +1,15 @@
 package com.badoo.ribs.sandbox.rib.dialog_example.dialog
 
+import com.badoo.ribs.android.dialog.Dialog
 import com.badoo.ribs.sandbox.rib.dialog_example.routing.DialogExampleChildBuilders
 
 class Dialogs internal constructor(
     builders: DialogExampleChildBuilders
 ) {
-    val themeDialog = ThemeDialog()
-    val simpleDialog = SimpleDialog()
-    val lazyDialog = LazyDialog()
-    val ribDialog = RibDialog(
+    val themeDialog: Dialog<Dialog.Event> = ThemeDialog()
+    val simpleDialog: Dialog<Dialog.Event> = SimpleDialog()
+    val lazyDialog: Dialog<Dialog.Event> = LazyDialog()
+    val ribDialog: Dialog<Dialog.Event> = RibDialog(
         builders.loremIpsum
     )
 }

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/Dialogs.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/Dialogs.kt
@@ -6,7 +6,7 @@ import com.badoo.ribs.sandbox.rib.dialog_example.routing.DialogExampleChildBuild
 class Dialogs internal constructor(
     builders: DialogExampleChildBuilders
 ) {
-    val themeDialog: Dialog<Dialog.Event> = ThemeDialog()
+    val themedDialog: Dialog<Dialog.Event> = ThemedDialog()
     val simpleDialog: Dialog<Dialog.Event> = SimpleDialog()
     val lazyDialog: Dialog<Dialog.Event> = LazyDialog()
     val ribDialog: Dialog<Dialog.Event> = RibDialog(

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/RibDialog.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/RibDialog.kt
@@ -4,12 +4,13 @@ import com.badoo.ribs.android.text.Text
 import com.badoo.ribs.android.dialog.Dialog
 import com.badoo.ribs.android.dialog.Dialog.Event.Negative
 import com.badoo.ribs.android.dialog.Dialog.Event.Positive
+import com.badoo.ribs.sandbox.R
 import com.badoo.ribs.sandbox.rib.lorem_ipsum.LoremIpsumBuilder
 
 class RibDialog(
     loremIpsumBuilder: LoremIpsumBuilder
 ) : Dialog<Dialog.Event>({
-        title = Text.Plain("A title if you wish")
+        title = Text.Resource(R.string.a_title_you_wish)
         ribFactory {
             loremIpsumBuilder.build(it)
         }

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/ThemeDialog.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/ThemeDialog.kt
@@ -1,0 +1,27 @@
+package com.badoo.ribs.sandbox.rib.dialog_example.dialog
+
+import com.badoo.ribs.android.text.Text
+import com.badoo.ribs.android.dialog.Dialog
+import com.badoo.ribs.android.dialog.Dialog.CancellationPolicy.Cancellable
+import com.badoo.ribs.android.dialog.Dialog.Event.Negative
+import com.badoo.ribs.android.dialog.Dialog.Event.Neutral
+import com.badoo.ribs.android.dialog.Dialog.Event.Positive
+import com.badoo.ribs.sandbox.R
+
+
+class ThemeDialog : Dialog<Dialog.Event>({
+    // Inject (Smart)Resources in constructor to resolve texts if needed
+    title = Text.Plain("Theme dialog")
+    message = Text.Plain("Lorem ipsum dolor sit amet")
+    buttons {
+        positive(Text.Plain("Yay!"), Positive)
+        negative(Text.Plain("No way"), Negative)
+        neutral(Text.Plain("Meh?"), Neutral)
+    }
+    themeResId = R.style.AppTheme_ThemeDialog
+
+    cancellationPolicy = Cancellable(
+        event = Event.Cancelled,
+        cancelOnTouchOutside = false
+    )
+})

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/ThemedDialog.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/ThemedDialog.kt
@@ -9,16 +9,16 @@ import com.badoo.ribs.android.dialog.Dialog.Event.Positive
 import com.badoo.ribs.sandbox.R
 
 
-class ThemeDialog : Dialog<Dialog.Event>({
+class ThemedDialog : Dialog<Dialog.Event>({
     // Inject (Smart)Resources in constructor to resolve texts if needed
-    title = Text.Plain("Theme dialog")
+    title = Text.Plain("Themed dialog")
     message = Text.Plain("Lorem ipsum dolor sit amet")
     buttons {
         positive(Text.Plain("Yay!"), Positive)
         negative(Text.Plain("No way"), Negative)
         neutral(Text.Plain("Meh?"), Neutral)
     }
-    themeResId = R.style.AppTheme_ThemeDialog
+    themeResId = R.style.AppTheme_ThemedDialog
 
     cancellationPolicy = Cancellable(
         event = Event.Cancelled,

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/ThemedDialog.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/dialog/ThemedDialog.kt
@@ -11,7 +11,7 @@ import com.badoo.ribs.sandbox.R
 
 class ThemedDialog : Dialog<Dialog.Event>({
     // Inject (Smart)Resources in constructor to resolve texts if needed
-    title = Text.Plain("Themed dialog")
+    title = Text.Resource(R.string.show_themed_dialog)
     message = Text.Plain("Lorem ipsum dolor sit amet")
     buttons {
         positive(Text.Plain("Yay!"), Positive)

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/routing/DialogExampleRouter.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/routing/DialogExampleRouter.kt
@@ -30,7 +30,7 @@ class DialogExampleRouter(
             @Parcelize object Default : Content()
         }
         sealed class Overlay : Configuration() {
-            @Parcelize object ThemeDialog : Overlay()
+            @Parcelize object ThemedDialog : Overlay()
             @Parcelize object SimpleDialog : Overlay()
             @Parcelize object LazyDialog : Overlay()
             @Parcelize object RibDialog : Overlay()
@@ -42,7 +42,7 @@ class DialogExampleRouter(
         when (routing.configuration) {
             is Content.Default -> noop()
             // TODO can be done with factory to remove first 3 params and make it simpler
-            is Overlay.ThemeDialog -> showDialog(routingSource, routing.identifier, dialogLauncher, dialogs.themeDialog)
+            is Overlay.ThemedDialog -> showDialog(routingSource, routing.identifier, dialogLauncher, dialogs.themedDialog)
             is Overlay.SimpleDialog -> showDialog(routingSource, routing.identifier, dialogLauncher, dialogs.simpleDialog)
             is Overlay.LazyDialog -> showDialog(routingSource, routing.identifier, dialogLauncher, dialogs.lazyDialog)
             is Overlay.RibDialog -> showDialog(routingSource, routing.identifier, dialogLauncher, dialogs.ribDialog)

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/routing/DialogExampleRouter.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/routing/DialogExampleRouter.kt
@@ -30,6 +30,7 @@ class DialogExampleRouter(
             @Parcelize object Default : Content()
         }
         sealed class Overlay : Configuration() {
+            @Parcelize object ThemeDialog : Overlay()
             @Parcelize object SimpleDialog : Overlay()
             @Parcelize object LazyDialog : Overlay()
             @Parcelize object RibDialog : Overlay()
@@ -41,6 +42,7 @@ class DialogExampleRouter(
         when (routing.configuration) {
             is Content.Default -> noop()
             // TODO can be done with factory to remove first 3 params and make it simpler
+            is Overlay.ThemeDialog -> showDialog(routingSource, routing.identifier, dialogLauncher, dialogs.themeDialog)
             is Overlay.SimpleDialog -> showDialog(routingSource, routing.identifier, dialogLauncher, dialogs.simpleDialog)
             is Overlay.LazyDialog -> showDialog(routingSource, routing.identifier, dialogLauncher, dialogs.lazyDialog)
             is Overlay.RibDialog -> showDialog(routingSource, routing.identifier, dialogLauncher, dialogs.ribDialog)

--- a/sandbox/src/main/res/layout/rib_dialog_example.xml
+++ b/sandbox/src/main/res/layout/rib_dialog_example.xml
@@ -14,18 +14,28 @@
         android:textStyle="bold"
         android:layout_margin="24dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/show_simple_dialog"
+        app:layout_constraintBottom_toTopOf="@id/show_theme_dialog"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
         tools:text="3826750182" />
 
     <Button
+        android:id="@+id/show_theme_dialog"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/show_theme_dialog"
+        app:layout_constraintTop_toBottomOf="@id/dialogs_example_debug"
+        app:layout_constraintBottom_toTopOf="@id/show_simple_dialog"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Button
         android:id="@+id/show_simple_dialog"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/show_simple_dialog"
-        app:layout_constraintTop_toBottomOf="@id/dialogs_example_debug"
+        app:layout_constraintTop_toBottomOf="@id/show_theme_dialog"
         app:layout_constraintBottom_toTopOf="@id/show_lazy_dialog"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/sandbox/src/main/res/layout/rib_dialog_example.xml
+++ b/sandbox/src/main/res/layout/rib_dialog_example.xml
@@ -14,29 +14,29 @@
         android:textStyle="bold"
         android:layout_margin="24dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/show_theme_dialog"
+        app:layout_constraintBottom_toTopOf="@id/show_themed_dialog"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
         tools:text="3826750182" />
 
     <Button
-        android:id="@+id/show_theme_dialog"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/show_theme_dialog"
-        app:layout_constraintTop_toBottomOf="@id/dialogs_example_debug"
-        app:layout_constraintBottom_toTopOf="@id/show_simple_dialog"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <Button
         android:id="@+id/show_simple_dialog"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/show_simple_dialog"
-        app:layout_constraintTop_toBottomOf="@id/show_theme_dialog"
+        app:layout_constraintTop_toBottomOf="@id/show_themed_dialog"
         app:layout_constraintBottom_toTopOf="@id/show_lazy_dialog"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Button
+        android:id="@+id/show_themed_dialog"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/show_themed_dialog"
+        app:layout_constraintTop_toBottomOf="@id/dialogs_example_debug"
+        app:layout_constraintBottom_toTopOf="@id/show_simple_dialog"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/sandbox/src/main/res/values/colors.xml
+++ b/sandbox/src/main/res/values/colors.xml
@@ -3,4 +3,7 @@
     <color name="colorPrimary">#008577</color>
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
+
+    <color name="red">#f00</color>
+    <color name="blue">#00f</color>
 </resources>

--- a/sandbox/src/main/res/values/strings.xml
+++ b/sandbox/src/main/res/values/strings.xml
@@ -13,4 +13,6 @@
     <string name="show_rib_dialog">RIB dialog</string>
     <string name="show_blocker">Show blocker in parent</string>
     <string name="close">Close</string>
+    <string name="a_title_you_wish">A title if you wish</string>
+    <string name="lazy_dialog_title">Lazy dialog title</string>
 </resources>

--- a/sandbox/src/main/res/values/strings.xml
+++ b/sandbox/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="check_permissions">Check permissions</string>
     <string name="request_permissions">Request permissions</string>
     <string name="random_button">Random button in a RIB</string>
+    <string name="show_theme_dialog">Simple theme dialog</string>
     <string name="show_simple_dialog">Simple dialog</string>
     <string name="show_lazy_dialog">Lazy dialog</string>
     <string name="show_rib_dialog">RIB dialog</string>

--- a/sandbox/src/main/res/values/strings.xml
+++ b/sandbox/src/main/res/values/strings.xml
@@ -7,8 +7,8 @@
     <string name="check_permissions">Check permissions</string>
     <string name="request_permissions">Request permissions</string>
     <string name="random_button">Random button in a RIB</string>
-    <string name="show_theme_dialog">Simple theme dialog</string>
     <string name="show_simple_dialog">Simple dialog</string>
+    <string name="show_themed_dialog">Themed dialog</string>
     <string name="show_lazy_dialog">Lazy dialog</string>
     <string name="show_rib_dialog">RIB dialog</string>
     <string name="show_blocker">Show blocker in parent</string>

--- a/sandbox/src/main/res/values/styles.xml
+++ b/sandbox/src/main/res/values/styles.xml
@@ -17,17 +17,17 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
-    <style name="AppTheme.ThemeDialog" parent="ThemeOverlay.AppCompat.Dialog.Alert">
+    <style name="AppTheme.ThemedDialog" parent="ThemeOverlay.AppCompat.Dialog.Alert">
         <item name="dialogCornerRadius">20dp</item>
-        <item name="buttonBarNegativeButtonStyle">@style/AppTheme.ThemeDialog.Negative</item>
-        <item name="buttonBarPositiveButtonStyle">@style/AppTheme.ThemeDialog.Positive</item>
+        <item name="buttonBarNegativeButtonStyle">@style/AppTheme.ThemedDialog.Negative</item>
+        <item name="buttonBarPositiveButtonStyle">@style/AppTheme.ThemedDialog.Positive</item>
     </style>
 
-    <style name="AppTheme.ThemeDialog.Negative" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+    <style name="AppTheme.ThemedDialog.Negative" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
         <item name="android:textColor">#f00</item>
     </style>
 
-    <style name="AppTheme.ThemeDialog.Positive" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+    <style name="AppTheme.ThemedDialog.Positive" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
         <item name="android:textColor">#00f</item>
     </style>
 

--- a/sandbox/src/main/res/values/styles.xml
+++ b/sandbox/src/main/res/values/styles.xml
@@ -24,11 +24,11 @@
     </style>
 
     <style name="AppTheme.ThemedDialog.Negative" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
-        <item name="android:textColor">#f00</item>
+        <item name="android:textColor">@color/red</item>
     </style>
 
     <style name="AppTheme.ThemedDialog.Positive" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
-        <item name="android:textColor">#00f</item>
+        <item name="android:textColor">@color/blue</item>
     </style>
 
 </resources>

--- a/sandbox/src/main/res/values/styles.xml
+++ b/sandbox/src/main/res/values/styles.xml
@@ -17,4 +17,18 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
+    <style name="AppTheme.ThemeDialog" parent="ThemeOverlay.AppCompat.Dialog.Alert">
+        <item name="dialogCornerRadius">20dp</item>
+        <item name="buttonBarNegativeButtonStyle">@style/AppTheme.ThemeDialog.Negative</item>
+        <item name="buttonBarPositiveButtonStyle">@style/AppTheme.ThemeDialog.Positive</item>
+    </style>
+
+    <style name="AppTheme.ThemeDialog.Negative" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+        <item name="android:textColor">#f00</item>
+    </style>
+
+    <style name="AppTheme.ThemeDialog.Positive" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+        <item name="android:textColor">#00f</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: Add a nullable `themeResId` in `Dialog` abstraction class for allowing library users to apply a specific style into their `AlertDialogs`. An example can be found in Dialog tab in `sandbox` app.

This `themeResId` will allow to change text colours, text sizes, background, fonts, etc.

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
