### PR TITLE
Remove unnecessary class reference from RibCustomisationDirectoryImpl

### DIFF
--- a/libraries/rib-base/src/main/java/com/badoo/ribs/core/customisation/RibCustomisationDirectoryImpl.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/core/customisation/RibCustomisationDirectoryImpl.kt
@@ -9,10 +9,6 @@ open class RibCustomisationDirectoryImpl(
 
     private val map: MutableMap<Any, Any> = hashMapOf()
 
-    inline fun <reified T : Any> put(value: T) {
-        put(T::class, value)
-    }
-
     override fun <T : RibCustomisation> put(key: KClass<T>, value: T) {
         map[key] = value
     }
@@ -31,7 +27,7 @@ open class RibCustomisationDirectoryImpl(
         map[key] as? T
 
     override fun <T : RibCustomisation> getRecursively(key: KClass<T>): T? =
-       get(key) ?: parent?.get(key)
+        get(key) ?: parent?.get(key)
 
     override fun <T : Rib> putSubDirectory(key: KClass<T>, value: RibCustomisationDirectory) {
         map[key] = value


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: `RibCustomisationDirectoryImpl` had an extra class reference in the removed function that was unnecessary and unused.

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
