### PR TITLE
Init routing only after rib/node references are set

### DIFF
--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/router/Router.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/router/Router.kt
@@ -67,6 +67,10 @@ abstract class Router<C : Parcelable>(
     override fun init(node: Node<*>) {
         this.node = node
         activator = RoutingActivator(node, clientChildActivator)
+    }
+
+    override fun onBuild() {
+        super.onBuild()
         initFeatures(node)
     }
 

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/RouterTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/RouterTest.kt
@@ -71,6 +71,7 @@ class RouterTest {
 
     @Test
     fun `Save instance state call reaches child nodes`() {
+        router.onBuild()
         router.onCreate(mock())
         router.onSaveInstanceState(mock())
         verify(childNodeC2_1).onSaveInstanceState(any())


### PR DESCRIPTION
After restoration (e.g. DKA), routing re-initialisation happened earlier than proper references were set. This fixes that.