### PR TITLE
Fix activeConfiguration being set up forever with the first state

### DIFF
--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/source/backstack/BackStack.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/source/backstack/BackStack.kt
@@ -69,7 +69,7 @@ class BackStack<C : Parcelable> internal constructor(
         TimeCapsule(buildParams.savedInstanceState)
     )
 
-    override fun baseLineState(fromRestored: Boolean): RoutingHistory<C>  =
+    override fun baseLineState(fromRestored: Boolean): RoutingHistory<C> =
         timeCapsule.initialState()
 
     private val store = object : Store<State<C>>(timeCapsule.initialState()) {
@@ -143,8 +143,8 @@ class BackStack<C : Parcelable> internal constructor(
                     .configuration
             }
 
-    val activeConfiguration: C =
-        state.elements
+    val activeConfiguration: C
+        get()= state.elements
             .last()
             .routing
             .configuration


### PR DESCRIPTION
Active config is not properly retrieved
