### PR TITLE
Succesive transition bug fix[WIP - test missing]

### DIFF
--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/PendingTransition.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/PendingTransition.kt
@@ -21,6 +21,13 @@ internal class PendingTransition<C : Parcelable>(
     fun schedule(handler: Handler, transitionHandler: TransitionHandler<C>) {
         emitter.invoke(RoutingStatePool.Effect.RequestTransition(this))
 
+        /**
+         * Entering views at this point are created but will be measured / laid out the next frame.
+         * We need to base calculations in transition implementations based on their actual measurements,
+         * but without them appearing just yet to avoid flickering.
+         * Making them invisible, starting the transitions then making them visible achieves the above.
+         */
+
         val enteringElements = transitionElements.filter { it.direction == TransitionDirection.ENTER }
         enteringElements.visibility(View.INVISIBLE)
         handler.post {

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/PendingTransition.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/PendingTransition.kt
@@ -1,0 +1,66 @@
+package com.badoo.ribs.routing.state.feature
+
+import android.os.Handler
+import android.os.Parcelable
+import android.view.View
+import com.badoo.ribs.routing.state.action.single.ReversibleAction
+import com.badoo.ribs.routing.state.changeset.TransitionDescriptor
+import com.badoo.ribs.routing.transition.TransitionDirection
+import com.badoo.ribs.routing.transition.TransitionElement
+import com.badoo.ribs.routing.transition.handler.TransitionHandler
+
+internal class PendingTransition<C : Parcelable>(
+    val descriptor: TransitionDescriptor,
+    private val direction: TransitionDirection,
+    private var actions: List<ReversibleAction<C>>,
+    private val transitionElements: List<TransitionElement<C>>,
+    private val emitter: EffectEmitter<C>) {
+
+    private var isDiscarded = false
+
+    fun schedule(handler: Handler, transitionHandler: TransitionHandler<C>) {
+        emitter.invoke(RoutingStatePool.Effect.RequestTransition(this))
+
+        val enteringElements = transitionElements.filter { it.direction == TransitionDirection.ENTER }
+        enteringElements.visibility(View.INVISIBLE)
+        handler.post {
+            enteringElements.visibility(View.VISIBLE)
+
+            if (isDiscarded.not()) {
+                consume(transitionHandler)
+            }
+        }
+    }
+
+    private fun consume(transitionHandler: TransitionHandler<C>) {
+        discard()
+        val transitionPair = transitionHandler.onTransition(transitionElements)
+        // TODO consider whether splitting this two two instances (one per direction, so that
+        //  enter and exit can be controlled separately) is better
+        OngoingTransition(
+            descriptor = descriptor,
+            direction = direction,
+            transitionPair = transitionPair,
+            actions = actions,
+            transitionElements = transitionElements,
+            emitter = emitter
+        ).start()
+    }
+
+    fun completeWithoutTransition() {
+        discard()
+        actions.forEach { it.onTransition() }
+        actions.forEach { it.onFinish() }
+    }
+
+    fun discard() {
+        isDiscarded = true
+        emitter.invoke(RoutingStatePool.Effect.RemovePendingTransition(this))
+    }
+
+    private fun List<TransitionElement<C>>.visibility(visibility: Int) {
+        forEach {
+            it.view.visibility = visibility
+        }
+    }
+}

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/RoutingStatePool.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/RoutingStatePool.kt
@@ -115,6 +115,14 @@ internal class RoutingStatePool<C : Parcelable>(
             ) : Individual<C>()
         }
 
+        class RequestTransition<C : Parcelable>(
+            val pendingTransition: PendingTransition<C>
+        ) : Effect<C>()
+
+        class RemovePendingTransition<C : Parcelable>(
+            val pendingTransition: PendingTransition<C>
+        ) : Effect<C>()
+
         data class TransitionStarted<C : Parcelable>(
             val transition: OngoingTransition<C>
         ) : Effect<C>()
@@ -145,6 +153,8 @@ internal class RoutingStatePool<C : Parcelable>(
         when (effect) {
             is Effect.Global -> state.global(effect)
             is Effect.Individual -> state.individual(effect)
+            is Effect.RemovePendingTransition -> state.copy(pendingTransition = state.pendingTransition - effect.pendingTransition)
+            is Effect.RequestTransition -> state.copy(pendingTransition = state.pendingTransition + effect.pendingTransition)
             is Effect.TransitionStarted -> state.copy(ongoingTransitions = state.ongoingTransitions + effect.transition)
             is Effect.TransitionFinished -> state.copy(ongoingTransitions = state.ongoingTransitions - effect.transition)
         }

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/state/WorkingState.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/state/WorkingState.kt
@@ -5,6 +5,7 @@ import com.badoo.ribs.routing.Routing
 import com.badoo.ribs.routing.state.Pool
 import com.badoo.ribs.routing.state.RoutingContext
 import com.badoo.ribs.routing.state.feature.OngoingTransition
+import com.badoo.ribs.routing.state.feature.PendingTransition
 import com.badoo.ribs.routing.state.poolOf
 
 /**
@@ -18,7 +19,8 @@ internal data class WorkingState<C : Parcelable>(
     val pool: Pool<C> = poolOf(),
     val pendingDeactivate: Set<Routing<C>> = setOf(),
     val pendingRemoval: Set<Routing<C>> = setOf(),
-    val ongoingTransitions: List<OngoingTransition<C>> = emptyList()
+    val ongoingTransitions: List<OngoingTransition<C>> = emptyList(),
+    val pendingTransition: List<PendingTransition<C>> = emptyList()
 ) {
     /**
      * Converts the [WorkingState] to [SavedState] by shrinking all


### PR DESCRIPTION
The original bug in Badoo PQW was caused by two factors. 
First one, a bug in the PQW feature that was sending and extra configuration operation to the rib. So basically some rogue event was generated when changing config from a certain configuration telling the rib to navigate to the current config again. E.g Current config is B, features ask for replace(A), feature ask for replace(B) inmediately

Second factor, the RIB bug :bug::
The rib bug is caused when calling two routing actions too fast. The issue is that they overlap, and for example, when calling some routing action and calling it transition immediately. This transition overlapping result in both children detached.
The source of the bug is in the rib Actor. When starting a transition a handler.post{} is used to start the transition. The reason to do so can be found in the code itself:
/**
 * Entering views at this point are created but will be measured / laid out the next frame.
 * We need to base calculations in transition implementations based on their actual measurements,
 * but without them appearing just yet to avoid flickering.
 * Making them invisible, starting the transitions then making them visible achieves the above.
 */

However, this cause the transition actual start to be enqueued. Thus, if  some new routing action was called immediately after the first one, there is not ongoing operation, and then, second transition is going to be started following the same process. And here we have the transition overlap causing the unexpected issue.

The solution:
The proposed solution is just to keep track of the transition until it really start. If along that time windows some new transition is requested, the actor react and handle that scenario to keep a consistent behaviour.