### PR TITLE
Gradle dependency declaration fix

### DIFF
--- a/app-example/build.gradle
+++ b/app-example/build.gradle
@@ -61,8 +61,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     implementation deps.android.appCompat
     implementation deps.android.design
     implementation deps.android.constraintLayout

--- a/libraries/rib-base-test-activity/build.gradle
+++ b/libraries/rib-base-test-activity/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     compileOnly project(':libraries:rib-base')
     implementation deps.android.annotations
     implementation deps.android.appCompat
-    implementation deps.external.kotlinStdlib
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/libraries/rib-base-test-rx2/build.gradle
+++ b/libraries/rib-base-test-rx2/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     compileOnly deps.external.rxrelay2
     compileOnly deps.external.rxjava2
 
-    implementation deps.external.kotlinStdlib
     implementation deps.android.annotations
     implementation deps.android.runner
     implementation deps.test.junit

--- a/libraries/rib-base-test/build.gradle
+++ b/libraries/rib-base-test/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     compileOnly deps.external.rxrelay2
     compileOnly deps.external.rxjava2
 
-    implementation deps.external.kotlinStdlib
     implementation deps.android.annotations
     implementation deps.android.runner
     implementation deps.test.junit

--- a/libraries/rib-base/build.gradle
+++ b/libraries/rib-base/build.gradle
@@ -9,11 +9,10 @@ androidExtensions {
 dependencies {
     api deps.android.appCompat
 
-    implementation deps.android.lifecycleCommon
+    api deps.android.lifecycleCommon
     implementation deps.android.activity
     implementation deps.android.fragment
     compileOnly deps.android.annotations
-    implementation deps.external.kotlinStdlib
 
     testImplementation deps.external.mviCore
     testImplementation deps.external.mviCoreAndroid

--- a/libraries/rib-compose/build.gradle
+++ b/libraries/rib-compose/build.gradle
@@ -42,7 +42,6 @@ android {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     compileOnly deps.apt.javax
 
     implementation deps.compose.runtime

--- a/libraries/rib-debug-utils/build.gradle
+++ b/libraries/rib-debug-utils/build.gradle
@@ -1,8 +1,7 @@
 configureAndroidLibrary(project)
 
 dependencies {
-    implementation project(":libraries:rib-base")
-    implementation deps.external.kotlinStdlib
+    api project(":libraries:rib-base")
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/libraries/rib-portal-rx/build.gradle
+++ b/libraries/rib-portal-rx/build.gradle
@@ -17,17 +17,13 @@ dependencies {
 
     implementation deps.apt.javaxInject
 
-    implementation deps.android.recyclerView
-    implementation deps.android.lifecycleCommon
     compileOnly deps.android.annotations
-    implementation deps.external.kotlinStdlib
     implementation deps.external.mviCore
     implementation deps.external.mviCoreAndroid
     implementation deps.external.rxrelay2
     implementation deps.external.rxjava2
 
     api project(":libraries:rib-portal")
-    implementation project(":libraries:rib-base")
     implementation project(':libraries:rib-rx2')
 
     testImplementation deps.android.annotations

--- a/libraries/rib-portal/build.gradle
+++ b/libraries/rib-portal/build.gradle
@@ -17,11 +17,8 @@ dependencies {
 
     implementation deps.apt.javaxInject
 
-    implementation deps.android.recyclerView
-    implementation deps.android.lifecycleCommon
     compileOnly deps.android.annotations
-    implementation deps.external.kotlinStdlib
-    implementation project(":libraries:rib-base")
+    api project(":libraries:rib-base")
 
     testImplementation deps.android.annotations
     testImplementation deps.test.junit

--- a/libraries/rib-recyclerview/build.gradle
+++ b/libraries/rib-recyclerview/build.gradle
@@ -18,9 +18,7 @@ dependencies {
     implementation deps.apt.javaxInject
 
     implementation deps.android.recyclerView
-    implementation deps.android.lifecycleCommon
     compileOnly deps.android.annotations
-    implementation deps.external.kotlinStdlib
     implementation deps.external.mviCore
     implementation deps.external.mviCoreAndroid
     implementation deps.external.rxrelay2

--- a/libraries/rib-rx2/build.gradle
+++ b/libraries/rib-rx2/build.gradle
@@ -7,11 +7,10 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-    implementation deps.external.rxrelay2
-    implementation deps.external.rxjava2
+    api deps.external.rxrelay2
+    api deps.external.rxjava2
 
-    implementation project(":libraries:rib-base")
+    api project(":libraries:rib-base")
 
     testImplementation deps.android.annotations
     testImplementation deps.test.junit

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     implementation localGroovy()
     implementation gradleApi()
     implementation deps.build.gradlePlugins.android
-    implementation deps.external.kotlinStdlib
     implementation deps.external.gson
 }
 

--- a/samples/back-stack/build.gradle
+++ b/samples/back-stack/build.gradle
@@ -30,8 +30,6 @@ androidExtensions {
 
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/samples/build-time-dependencies/build.gradle
+++ b/samples/build-time-dependencies/build.gradle
@@ -32,7 +32,6 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/samples/communication-between-nodes-1/build.gradle
+++ b/samples/communication-between-nodes-1/build.gradle
@@ -30,8 +30,6 @@ androidExtensions {
 
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/samples/customisations-app/build.gradle
+++ b/samples/customisations-app/build.gradle
@@ -29,7 +29,6 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/samples/dialogs/build.gradle
+++ b/samples/dialogs/build.gradle
@@ -29,7 +29,6 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/samples/hello-world/build.gradle
+++ b/samples/hello-world/build.gradle
@@ -29,7 +29,6 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/samples/plugins/build.gradle
+++ b/samples/plugins/build.gradle
@@ -32,8 +32,6 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/samples/retained-instance-store/build.gradle
+++ b/samples/retained-instance-store/build.gradle
@@ -22,7 +22,6 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/samples/simple-routing-app/build.gradle
+++ b/samples/simple-routing-app/build.gradle
@@ -29,7 +29,6 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/samples/simple-routing-rib/build.gradle
+++ b/samples/simple-routing-rib/build.gradle
@@ -28,7 +28,6 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout
     implementation deps.android.design

--- a/sandbox-compose-placeholder/build.gradle
+++ b/sandbox-compose-placeholder/build.gradle
@@ -35,7 +35,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     compileOnly deps.apt.javax
 
     implementation deps.android.appCompat

--- a/sandbox-compose/build.gradle
+++ b/sandbox-compose/build.gradle
@@ -45,7 +45,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     compileOnly deps.apt.javax
 
     implementation deps.android.appCompat

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -50,7 +50,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
     compileOnly deps.apt.javax
 
     implementation deps.android.appCompat

--- a/templates/common-template.gradle
+++ b/templates/common-template.gradle
@@ -9,8 +9,6 @@ androidExtensions {
 }
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     kapt deps.apt.daggerCompiler
     compileOnly deps.apt.javax
 

--- a/tooling/rib-intellij-plugin/build.gradle
+++ b/tooling/rib-intellij-plugin/build.gradle
@@ -152,7 +152,6 @@ templates {
 dependencies {
     implementation deps.build.commonsLang
     implementation deps.android.annotations
-    implementation deps.external.kotlinStdlib
     implementation deps.external.apacheCommons
     implementation deps.external.gson
 

--- a/tutorials/tutorial1/build.gradle
+++ b/tutorials/tutorial1/build.gradle
@@ -30,8 +30,6 @@ androidExtensions {
 
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     kapt deps.apt.daggerCompiler
     compileOnly deps.apt.javax
 

--- a/tutorials/tutorial2/build.gradle
+++ b/tutorials/tutorial2/build.gradle
@@ -30,8 +30,6 @@ androidExtensions {
 
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     kapt deps.apt.daggerCompiler
     compileOnly deps.apt.javax
 

--- a/tutorials/tutorial3/build.gradle
+++ b/tutorials/tutorial3/build.gradle
@@ -30,8 +30,6 @@ androidExtensions {
 
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     kapt deps.apt.daggerCompiler
     compileOnly deps.apt.javax
 

--- a/tutorials/tutorial4/build.gradle
+++ b/tutorials/tutorial4/build.gradle
@@ -30,8 +30,6 @@ androidExtensions {
 
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     kapt deps.apt.daggerCompiler
     compileOnly deps.apt.javax
 

--- a/tutorials/tutorial5/build.gradle
+++ b/tutorials/tutorial5/build.gradle
@@ -30,8 +30,6 @@ androidExtensions {
 
 
 dependencies {
-    implementation deps.external.kotlinStdlib
-
     kapt deps.apt.daggerCompiler
     compileOnly deps.apt.javax
 


### PR DESCRIPTION
In order to make local RIBs build work as expected we need to properly declare dependencies of the modules. `api` dependency should be used in the cases, when classes of the dependency is exposed as public API of the module. In our case it is  JetPack's Lifecycle and RxJava.

Also removed Kotlin stdlib because the latest Kotlin Gradle plugin adds it automatically. 