### PR TITLE
Use cache@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         timeout-minutes: 25
         env:
             JAVA_TOOL_OPTIONS: -Xmx6g
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.parallel=true
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1
@@ -53,7 +53,7 @@ jobs:
         timeout-minutes: 20
         env:
             JAVA_TOOL_OPTIONS: -Xmx4g
-            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.parallel=true
+            GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process
         strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,15 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - uses: actions/cache@v1
+            - uses: actions/cache@v2
               with:
-                  path: ~/.gradle/caches
-                  key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/gradle/dependencies.gradle') }}
-
+                path: |
+                  ~/.gradle/caches
+                  ~/.gradle/wrapper
+                key: ${{ runner.os }}-gradle-false-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                restore-keys: |
+                  ${{ runner.os }}-gradle-false-
+                  ${{ runner.os }}-gradle-
             - name: Assemble
               run: ./gradlew assemble
               working-directory: . 
@@ -61,10 +65,15 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - uses: actions/cache@v1
+            - uses: actions/cache@v2
               with:
-                  path: ~/.gradle/caches
-                  key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/gradle/dependencies.gradle') }}-${{ matrix.compose-enabled }}
+                path: |
+                  ~/.gradle/caches
+                  ~/.gradle/wrapper
+                key: ${{ runner.os }}-gradle-${{ matrix.compose-enabled }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                restore-keys: |
+                  ${{ runner.os }}-gradle-${{ matrix.compose-enabled }}-
+                  ${{ runner.os }}-gradle-
             - name: Unit tests
               run: ./gradlew testDebugUnitTest -PuseCompose=${{ matrix.compose-enabled }}
               working-directory: .
@@ -90,12 +99,15 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - uses: actions/cache@v1
+            - uses: actions/cache@v2
               with:
-                 path: ~/.gradle/caches
-                 key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/gradle/dependencies.gradle') }}-${{ matrix.compose-enabled }}
-
-
+                path: |
+                  ~/.gradle/caches
+                  ~/.gradle/wrapper
+                key: ${{ runner.os }}-gradle-${{ matrix.compose-enabled }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                restore-keys: |
+                  ${{ runner.os }}-gradle-${{ matrix.compose-enabled }}-
+                  ${{ runner.os }}-gradle-
             - name: Instrumentation tests
               uses: reactivecircus/android-emulator-runner@v2
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
                   ${{ runner.os }}-gradle-
             - name: Assemble
               run: ./gradlew assemble
-              working-directory: . 
+              working-directory: .
+            - name: Cleanup Gradle Cache
+              run: |
+                rm -f ~/.gradle/caches/modules-2/modules-2.lock
+                rm -f ~/.gradle/caches/modules-2/gc.properties
     detekt:
         runs-on: ubuntu-latest
         timeout-minutes: 10
@@ -77,6 +81,10 @@ jobs:
             - name: Unit tests
               run: ./gradlew testDebugUnitTest -PuseCompose=${{ matrix.compose-enabled }}
               working-directory: .
+            - name: Cleanup Gradle Cache
+              run: |
+                rm -f ~/.gradle/caches/modules-2/modules-2.lock
+                rm -f ~/.gradle/caches/modules-2/gc.properties
 
     instrumentation-tests:
         runs-on: macOS-latest
@@ -114,3 +122,7 @@ jobs:
                   api-level: ${{ matrix.api-level }}
                   arch: x86
                   script: ./gradlew connectedCheck -PuseCompose=${{ matrix.compose-enabled }}
+            - name: Cleanup Gradle Cache
+              run: |
+                rm -f ~/.gradle/caches/modules-2/modules-2.lock
+                rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=512M
+org.gradle.caching=true
 
 GROUP=com.badoo.ribs
 VERSION_NAME=0.26.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,9 @@
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=512M
 org.gradle.caching=true
+org.gradle.parallel=true
 
 GROUP=com.badoo.ribs
 VERSION_NAME=0.26.0


### PR DESCRIPTION
We are still using `cache@v1`. Upgrading to v2 can improve our CI stability (most of the failures because of cache step failure).
Applied [recommended setup](https://github.com/actions/cache/blob/main/examples.md#java---gradle) with `useCompose` split.