### PR TITLE
Add support for code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         classpath deps.build.gradlePlugins.kotlin
         classpath deps.build.gradlePlugins.mavenPublish
         classpath deps.build.gradlePlugins.detekt
+        classpath deps.build.gradlePlugins.jacoco
     }
 }
 

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -39,4 +39,9 @@ task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugU
     def kotlinSourceDirectory = "$project.projectDir/src/main/kotlin"
 
     sourceDirectories.setFrom(files([javaSourceDirectory, kotlinSourceDirectory]))
+
+    def unitTestsData = fileTree(dir: "${buildDir}/jacoco/", includes: ["**/*.exec"])
+    def androidTestsData = fileTree(dir: "${buildDir}/outputs/code_coverage/debugAndroidTest/connected/", includes: ["**/*.ec"])
+
+    executionData(files([unitTestsData, androidTestsData]))
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -60,3 +60,17 @@ task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugU
     sourceDirectories.setFrom(files([javaSourceDirectory, kotlinSourceDirectory]))
     executionData(files([unitTestsData, androidTestsData]))
 }
+
+task debugUnitTestCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
+
+    group = "Code coverage"
+    description = "Generate coverage reports on Unit tests for debug builds"
+
+    reports {
+        html.enabled = true
+    }
+
+    classDirectories.setFrom(files([javaClasses, kotlinClasses]))
+    sourceDirectories.setFrom(files([javaSourceDirectory, kotlinSourceDirectory]))
+    executionData(files([unitTestsData]))
+}

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -9,3 +9,9 @@ tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
     jacoco.excludes = ['jdk.internal.*']
 }
+
+task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+
+    group = "Code coverage"
+    description = "Generate coverage reports that combine both Unit and UI tests for debug builds"
+}

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -14,4 +14,8 @@ task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugU
 
     group = "Code coverage"
     description = "Generate coverage reports that combine both Unit and UI tests for debug builds"
+
+    reports {
+        html.enabled = true
+    }
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -27,4 +27,11 @@ task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugU
             '**/*Test*.*',
             'android/**/*.*'
     ]
+
+    def javaClasses = fileTree(dir: "${buildDir}/intermediates/javac/debug/classes",
+            excludes: exclusions)
+    def kotlinClasses = fileTree(dir: "${buildDir}/tmp/kotlin-classes/debug",
+            excludes: exclusions)
+
+    classDirectories.setFrom(files([javaClasses, kotlinClasses]))
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -1,1 +1,5 @@
 apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = deps.versions.jacoco
+}

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -10,6 +10,14 @@ tasks.withType(Test) {
     jacoco.excludes = ['jdk.internal.*']
 }
 
+android {
+    buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
+    }
+}
+
 task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
 
     group = "Code coverage"

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -16,6 +16,15 @@ android {
             testCoverageEnabled true
         }
     }
+    testOptions {
+        unitTests {
+            all {
+                // Issue tracker: https://issuetracker.google.com/issues/67872367
+                // Official documentation: https://www.jacoco.org/jacoco/trunk/doc/offline.html
+                systemProperty 'jacoco-agent.destfile', buildDir.path + '/jacoco/jacoco.exec'
+            }
+        }
+    }
 }
 
 task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -18,4 +18,13 @@ task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugU
     reports {
         html.enabled = true
     }
+
+    def exclusions = [
+            '**/R.class',
+            '**/R$*.class',
+            '**/BuildConfig.*',
+            '**/Manifest*.*',
+            '**/*Test*.*',
+            'android/**/*.*'
+    ]
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -74,3 +74,17 @@ task debugUnitTestCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugU
     sourceDirectories.setFrom(files([javaSourceDirectory, kotlinSourceDirectory]))
     executionData(files([unitTestsData]))
 }
+
+task debugUiTestCodeCoverageReport(type: JacocoReport, dependsOn: ['createDebugCoverageReport']) {
+
+    group = "Code coverage"
+    description = "Generate coverage reports on UI tests for debug builds"
+
+    reports {
+        html.enabled = true
+    }
+
+    classDirectories.setFrom(files([javaClasses, kotlinClasses]))
+    sourceDirectories.setFrom(files([javaSourceDirectory, kotlinSourceDirectory]))
+    executionData(files([androidTestsData]))
+}

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -27,6 +27,26 @@ android {
     }
 }
 
+def exclusions = [
+        '**/R.class',
+        '**/R$*.class',
+        '**/BuildConfig.*',
+        '**/Manifest*.*',
+        '**/*Test*.*',
+        'android/**/*.*'
+]
+
+def javaClasses = fileTree(dir: "${buildDir}/intermediates/javac/debug/classes",
+        excludes: exclusions)
+def kotlinClasses = fileTree(dir: "${buildDir}/tmp/kotlin-classes/debug",
+        excludes: exclusions)
+
+def javaSourceDirectory = "$project.projectDir/src/main/java"
+def kotlinSourceDirectory = "$project.projectDir/src/main/kotlin"
+
+def unitTestsData = fileTree(dir: "${buildDir}/jacoco/", includes: ["**/*.exec"])
+def androidTestsData = fileTree(dir: "${buildDir}/outputs/code_coverage/debugAndroidTest/connected/", includes: ["**/*.ec"])
+
 task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
 
     group = "Code coverage"
@@ -36,29 +56,7 @@ task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugU
         html.enabled = true
     }
 
-    def exclusions = [
-            '**/R.class',
-            '**/R$*.class',
-            '**/BuildConfig.*',
-            '**/Manifest*.*',
-            '**/*Test*.*',
-            'android/**/*.*'
-    ]
-
-    def javaClasses = fileTree(dir: "${buildDir}/intermediates/javac/debug/classes",
-            excludes: exclusions)
-    def kotlinClasses = fileTree(dir: "${buildDir}/tmp/kotlin-classes/debug",
-            excludes: exclusions)
-
     classDirectories.setFrom(files([javaClasses, kotlinClasses]))
-
-    def javaSourceDirectory = "$project.projectDir/src/main/java"
-    def kotlinSourceDirectory = "$project.projectDir/src/main/kotlin"
-
     sourceDirectories.setFrom(files([javaSourceDirectory, kotlinSourceDirectory]))
-
-    def unitTestsData = fileTree(dir: "${buildDir}/jacoco/", includes: ["**/*.exec"])
-    def androidTestsData = fileTree(dir: "${buildDir}/outputs/code_coverage/debugAndroidTest/connected/", includes: ["**/*.ec"])
-
     executionData(files([unitTestsData, androidTestsData]))
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -1,0 +1,1 @@
+apply plugin: 'jacoco'

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -2,4 +2,5 @@ apply plugin: 'jacoco'
 
 jacoco {
     toolVersion = deps.versions.jacoco
+    reportsDir = file("$buildDir/codeCoverageReports")
 }

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -4,3 +4,8 @@ jacoco {
     toolVersion = deps.versions.jacoco
     reportsDir = file("$buildDir/codeCoverageReports")
 }
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
+}

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -34,4 +34,9 @@ task debugCombinedCodeCoverageReport(type: JacocoReport, dependsOn: ['testDebugU
             excludes: exclusions)
 
     classDirectories.setFrom(files([javaClasses, kotlinClasses]))
+
+    def javaSourceDirectory = "$project.projectDir/src/main/java"
+    def kotlinSourceDirectory = "$project.projectDir/src/main/kotlin"
+
+    sourceDirectories.setFrom(files([javaSourceDirectory, kotlinSourceDirectory]))
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -46,7 +46,8 @@ def versions = [
     androidxTestUiAutoVersion:'2.2.0',
     retrofitVersion: '2.8.1',
     okhttp: '3.14.7',
-    leakCanary: '2.4'
+    leakCanary: '2.4',
+    jacoco: '0.8.6'
 ]
 
 def apt = [
@@ -79,6 +80,7 @@ def build = [
         gradleKotlinDsl: 'org.gradle.kotlin:plugins:1.2.2',
         mavenPublish: 'com.vanniktech:gradle-maven-publish-plugin:0.8.0',
         detekt: 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.10.0',
+        jacoco: "org.jacoco:org.jacoco.core:${versions.jacoco}"
     ]
 ]
 

--- a/libraries/rib-base/build.gradle
+++ b/libraries/rib-base/build.gradle
@@ -1,6 +1,7 @@
 configureAndroidLibrary(project)
 
 apply plugin: 'kotlin-android-extensions'
+apply from: rootProject.file('gradle/code-coverage.gradle')
 
 androidExtensions {
     experimental = true


### PR DESCRIPTION
**Description**:

This PR consists in adding code coverage support with Jacoco to the project.

It adds the 3 following Gradle tasks under the `code coverage` group:

<img width="321" alt="Screenshot 2021-04-01 at 16 20 52" src="https://user-images.githubusercontent.com/16627604/113308223-40222b00-9306-11eb-88ae-c813ac762598.png">

**Example**: 

<img width="1212" alt="Screenshot 2021-04-01 at 16 22 30" src="https://user-images.githubusercontent.com/16627604/113308788-cc345280-9306-11eb-954b-0b5216f489d3.png">
