### PR TITLE
Remove 3000ms, let it run with default timeout

### DIFF
--- a/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/dialogkeyboard/AlertDialogKeyboardTest.kt
+++ b/libraries/rib-base/src/androidTest/java/com/badoo/ribs/android/dialogkeyboard/AlertDialogKeyboardTest.kt
@@ -34,7 +34,7 @@ class AlertDialogKeyboardTest {
         setupRibs()
         onView(withClassName(endsWith("EditText"))).perform(click())
 
-        waitFor(3000) {
+        waitFor() {
             val inputManager = InstrumentationRegistry
                 .getInstrumentation()
                 .targetContext


### PR DESCRIPTION
This test is flaky with 3000ms failing too often. Hopefully this makes it better.