### PR TITLE
Remove child aware callbacks when parent lifecycle is destroyed

### DIFF
--- a/app-example/src/main/java/com/badoo/ribs/example/feed_container/FeedContainerInteractor.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/feed_container/FeedContainerInteractor.kt
@@ -19,7 +19,7 @@ internal class FeedContainerInteractor(
     override fun onCreate(nodeLifecycle: Lifecycle) {
         nodeLifecycle.createDestroy {
         }
-        whenChildBuilt<PhotoFeed> { commonLifecycle, child ->
+        whenChildBuilt<PhotoFeed>(nodeLifecycle) { commonLifecycle, child ->
             commonLifecycle.createDestroy {
                 bind(child.output to rib.output using FeedOutputToContainerOutput)
             }

--- a/app-example/src/main/java/com/badoo/ribs/example/logged_in_container/LoggedInContainerInteractor.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/logged_in_container/LoggedInContainerInteractor.kt
@@ -32,7 +32,7 @@ internal class LoggedInContainerInteractor(
     override fun onCreate(nodeLifecycle: Lifecycle) {
         nodeLifecycle.createDestroy {
         }
-        whenChildBuilt<FeedContainer> { commonLifecycle, child ->
+        whenChildBuilt<FeedContainer>(nodeLifecycle) { commonLifecycle, child ->
             commonLifecycle.createDestroy {
                 bind(child.output to photoFeedOutputConsumer)
             }

--- a/app-example/src/main/java/com/badoo/ribs/example/logged_out_container/LoggedOutContainerInteractor.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/logged_out_container/LoggedOutContainerInteractor.kt
@@ -24,7 +24,7 @@ internal class LoggedOutContainerInteractor(
     override fun onCreate(nodeLifecycle: Lifecycle) {
         nodeLifecycle.createDestroy {
         }
-        whenChildBuilt<Welcome> { commonLifecycle, child ->
+        whenChildBuilt<Welcome>(nodeLifecycle) { commonLifecycle, child ->
             commonLifecycle.createDestroy {
                 bind(child.output to welcomeListener)
             }

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAware.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAware.kt
@@ -15,26 +15,26 @@ import kotlin.reflect.KClass
 interface ChildAware : SubtreeChangeAware, NodeAware {
 
     fun <T : Rib> whenChildBuilt(
-        lifecycle: Lifecycle = node.lifecycle,
+        lifecycle: Lifecycle,
         child: KClass<T>,
         callback: ChildCallback<T>,
     )
 
     fun <T : Rib> whenChildAttached(
-        lifecycle: Lifecycle = node.lifecycle,
+        lifecycle: Lifecycle,
         child: KClass<T>,
         callback: ChildCallback<T>,
     )
 
     fun <T1 : Rib, T2 : Rib> whenChildrenBuilt(
-        lifecycle: Lifecycle = node.lifecycle,
+        lifecycle: Lifecycle,
         child1: KClass<T1>,
         child2: KClass<T2>,
         callback: ChildrenCallback<T1, T2>,
     )
 
     fun <T1 : Rib, T2 : Rib> whenChildrenAttached(
-        lifecycle: Lifecycle = node.lifecycle,
+        lifecycle: Lifecycle,
         child1: KClass<T1>,
         child2: KClass<T2>,
         callback: ChildrenCallback<T1, T2>,

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareCallbackInfo.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareCallbackInfo.kt
@@ -19,13 +19,16 @@ internal sealed class ChildAwareCallbackInfo {
     ) : ChildAwareCallbackInfo() {
 
         fun invokeIfRequired(newNode: Node<*>) {
+            if (parentLifecycle.isDestroyed) return
             val castedNode = child.safeCast(newNode)
             if (castedNode != null) {
+                val lifecycle =
+                    MinimumCombinedLifecycle(
+                        parentLifecycle,
+                        newNode.lifecycle,
+                    ).lifecycle
                 @Suppress("UNCHECKED_CAST")
-                callback(
-                    MinimumCombinedLifecycle(parentLifecycle, newNode.lifecycle).lifecycle,
-                    castedNode
-                )
+                callback(lifecycle, castedNode)
             }
         }
 
@@ -64,11 +67,12 @@ internal sealed class ChildAwareCallbackInfo {
 
         @Suppress("UNCHECKED_CAST")
         private fun notify(node1: Node<*>, node2: Node<*>) {
+            if (parentLifecycle.isDestroyed) return
             val lifecycle =
                 MinimumCombinedLifecycle(
                     parentLifecycle,
                     node1.lifecycle,
-                    node2.lifecycle
+                    node2.lifecycle,
                 ).lifecycle
             if (child1.isInstance(node1)) {
                 callback(lifecycle, child1.cast(node1), child2.cast(node2))

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareDSL.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareDSL.kt
@@ -1,0 +1,35 @@
+package com.badoo.ribs.clienthelper.childaware
+
+import androidx.lifecycle.Lifecycle
+import com.badoo.ribs.core.Rib
+
+class ChildAwareDSL(
+    private val childAware: ChildAware,
+    val lifecycle: Lifecycle,
+) : ChildAware by childAware {
+
+    inline fun <reified T : Rib> whenChildBuilt(
+        noinline callback: ChildCallback<T>,
+    ) {
+        whenChildBuilt(lifecycle, callback)
+    }
+
+    inline fun <reified T : Rib> whenChildAttached(
+        noinline callback: ChildCallback<T>,
+    ) {
+        whenChildAttached(lifecycle, callback)
+    }
+
+    inline fun <reified T1 : Rib, reified T2 : Rib> whenChildrenBuilt(
+        noinline callback: ChildrenCallback<T1, T2>,
+    ) {
+        whenChildrenBuilt(lifecycle, callback)
+    }
+
+    inline fun <reified T1 : Rib, reified T2 : Rib> whenChildrenAttached(
+        noinline callback: ChildrenCallback<T1, T2>,
+    ) {
+        whenChildrenAttached(lifecycle, callback)
+    }
+
+}

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareExt.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareExt.kt
@@ -3,31 +3,35 @@ package com.badoo.ribs.clienthelper.childaware
 import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.core.Rib
 
+/** Simplify usage of [ChildAware] by providing default lifecycle to every method. */
+fun ChildAware.childAware(lifecycle: Lifecycle, block: ChildAwareDSL.() -> Unit) {
+    ChildAwareDSL(this, lifecycle).block()
+}
+
 inline fun <reified T : Rib> ChildAware.whenChildBuilt(
-    lifecycle: Lifecycle = node.lifecycle,
+    lifecycle: Lifecycle,
     noinline callback: ChildCallback<T>,
 ) {
     whenChildBuilt(lifecycle, T::class, callback)
 }
 
 inline fun <reified T : Rib> ChildAware.whenChildAttached(
-    lifecycle: Lifecycle = node.lifecycle,
+    lifecycle: Lifecycle,
     noinline callback: ChildCallback<T>,
 ) {
     whenChildAttached(lifecycle, T::class, callback)
 }
 
 inline fun <reified T1 : Rib, reified T2 : Rib> ChildAware.whenChildrenBuilt(
-    lifecycle: Lifecycle = node.lifecycle,
+    lifecycle: Lifecycle,
     noinline callback: ChildrenCallback<T1, T2>,
 ) {
     whenChildrenBuilt(lifecycle, T1::class, T2::class, callback)
 }
 
 inline fun <reified T1 : Rib, reified T2 : Rib> ChildAware.whenChildrenAttached(
-    lifecycle: Lifecycle = node.lifecycle,
+    lifecycle: Lifecycle,
     noinline callback: ChildrenCallback<T1, T2>,
 ) {
     whenChildrenAttached(lifecycle, T1::class, T2::class, callback)
 }
-

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareExt.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareExt.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.core.Rib
 
 /** Simplify usage of [ChildAware] by providing default lifecycle to every method. */
-fun ChildAware.childAware(lifecycle: Lifecycle, block: ChildAwareDSL.() -> Unit) {
-    ChildAwareDSL(this, lifecycle).block()
+fun ChildAware.childAware(lifecycle: Lifecycle, block: ChildAwareScope.() -> Unit) {
+    ChildAwareScope(this, lifecycle).block()
 }
 
 inline fun <reified T : Rib> ChildAware.whenChildBuilt(

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareScope.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/ChildAwareScope.kt
@@ -3,7 +3,7 @@ package com.badoo.ribs.clienthelper.childaware
 import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.core.Rib
 
-class ChildAwareDSL(
+class ChildAwareScope(
     private val childAware: ChildAware,
     val lifecycle: Lifecycle,
 ) : ChildAware by childAware {

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/LifecycleExt.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/clienthelper/childaware/LifecycleExt.kt
@@ -1,0 +1,6 @@
+package com.badoo.ribs.clienthelper.childaware
+
+import androidx.lifecycle.Lifecycle
+
+internal val Lifecycle.isDestroyed
+    get() = currentState == Lifecycle.State.DESTROYED

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/childaware/ChildAwareImplTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/childaware/ChildAwareImplTest.kt
@@ -30,13 +30,15 @@ class ChildAwareImplTest {
     }.apply {
         onCreate()
     }
+    private val lifecycle: Lifecycle
+        get() = registry.node.lifecycle
 
     // region Single
 
     @Test
     fun `whenChildBuilt is invoked if registered before onChildBuilt`() {
         var capturedNode: Rib? = null
-        registry.whenChildBuilt<Child1> { _, child -> capturedNode = child }
+        registry.whenChildBuilt<Child1>(lifecycle) { _, child -> capturedNode = child }
         val child1 = createChild1(attach = false)
         assertEquals(child1, capturedNode)
     }
@@ -45,14 +47,14 @@ class ChildAwareImplTest {
     fun `whenChildBuilt is invoked if registered after onChildBuilt`() {
         val child1 = createChild1()
         var capturedNode: Rib? = null
-        registry.whenChildBuilt<Child1> { _, child -> capturedNode = child }
+        registry.whenChildBuilt<Child1>(lifecycle) { _, child -> capturedNode = child }
         assertEquals(child1, capturedNode)
     }
 
     @Test
     fun `whenChildAttached is invoked if registered before onChildAttached`() {
         var capturedNode: Rib? = null
-        registry.whenChildAttached<Child1> { _, child -> capturedNode = child }
+        registry.whenChildAttached<Child1>(lifecycle) { _, child -> capturedNode = child }
         val child1 = createChild1()
         assertEquals(child1, capturedNode)
     }
@@ -61,7 +63,7 @@ class ChildAwareImplTest {
     fun `whenChildAttached is invoked if registered after onChildAttached`() {
         val child1 = createChild1()
         var capturedNode: Rib? = null
-        registry.whenChildAttached<Child1> { _, child -> capturedNode = child }
+        registry.whenChildAttached<Child1>(lifecycle) { _, child -> capturedNode = child }
         assertEquals(child1, capturedNode)
     }
 
@@ -69,8 +71,10 @@ class ChildAwareImplTest {
     fun `every whenChildBuilt is invoked`() {
         var capturedNode1: Rib? = null
         var capturedNode2: Rib? = null
-        registry.whenChildBuilt<Child1> { _, child -> capturedNode1 = child }
-        registry.whenChildBuilt<Child1> { _, child -> capturedNode2 = child }
+        registry.childAware(lifecycle) {
+            whenChildBuilt<Child1> { _, child -> capturedNode1 = child }
+            whenChildBuilt<Child1> { _, child -> capturedNode2 = child }
+        }
         val child1 = createChild1(attach = false)
         assertEquals(child1, capturedNode1)
         assertEquals(child1, capturedNode2)
@@ -81,7 +85,7 @@ class ChildAwareImplTest {
         val child1 = createChild1()
         val child2 = createChild1()
         val capturedNodes = ArrayList<Rib>()
-        registry.whenChildBuilt<Child1> { _, child -> capturedNodes += child }
+        registry.whenChildBuilt<Child1>(lifecycle) { _, child -> capturedNodes += child }
         assertEquals(listOf(child1, child2), capturedNodes)
     }
 
@@ -89,7 +93,7 @@ class ChildAwareImplTest {
     fun `whenChildAttached is not invoked for unrelated child`() {
         createChild1()
         var capturedNode: Rib? = null
-        registry.whenChildAttached<Child2> { _, child -> capturedNode = child }
+        registry.whenChildAttached<Child2>(lifecycle) { _, child -> capturedNode = child }
         assertNull(capturedNode)
     }
 
@@ -100,7 +104,7 @@ class ChildAwareImplTest {
     @Test
     fun `whenChildrenBuilt is invoked if registered before onChildBuilt`() {
         val capturedNodes = ArrayList<Rib>()
-        registry.whenChildrenBuilt<Child1, Child2> { _, c1, c2 ->
+        registry.whenChildrenBuilt<Child1, Child2>(lifecycle) { _, c1, c2 ->
             capturedNodes += c1
             capturedNodes += c2
         }
@@ -114,7 +118,7 @@ class ChildAwareImplTest {
         val child1 = createChild1()
         val child2 = createChild2()
         val capturedNodes = ArrayList<Rib>()
-        registry.whenChildrenBuilt<Child1, Child2> { _, c1, c2 ->
+        registry.whenChildrenBuilt<Child1, Child2>(lifecycle) { _, c1, c2 ->
             capturedNodes += c1
             capturedNodes += c2
         }
@@ -124,7 +128,7 @@ class ChildAwareImplTest {
     @Test
     fun `whenChildrenAttached is invoked if registered before onChildAttached`() {
         val capturedNodes = ArrayList<Rib>()
-        registry.whenChildrenAttached<Child1, Child2> { _, c1, c2 ->
+        registry.whenChildrenAttached<Child1, Child2>(lifecycle) { _, c1, c2 ->
             capturedNodes += c1
             capturedNodes += c2
         }
@@ -138,7 +142,7 @@ class ChildAwareImplTest {
         val child1 = createChild1()
         val child2 = createChild2()
         val capturedNodes = ArrayList<Rib>()
-        registry.whenChildrenAttached<Child1, Child2> { _, c1, c2 ->
+        registry.whenChildrenAttached<Child1, Child2>(lifecycle) { _, c1, c2 ->
             capturedNodes += c1
             capturedNodes += c2
         }
@@ -150,7 +154,7 @@ class ChildAwareImplTest {
         createChild1()
         createChild3()
         val capturedNodes = ArrayList<Rib>()
-        registry.whenChildrenAttached<Child1, Child2> { _, c1, c2 ->
+        registry.whenChildrenAttached<Child1, Child2>(lifecycle) { _, c1, c2 ->
             capturedNodes += c1
             capturedNodes += c2
         }
@@ -164,7 +168,7 @@ class ChildAwareImplTest {
         val child21 = createChild2()
         val child22 = createChild2()
         val capturedNodes = ArrayList<Pair<Rib, Rib>>()
-        registry.whenChildrenAttached<Child1, Child2> { _, child1, child2 ->
+        registry.whenChildrenAttached<Child1, Child2>(lifecycle) { _, child1, child2 ->
             capturedNodes += child1 to child2
         }
         assertEquals(
@@ -179,7 +183,7 @@ class ChildAwareImplTest {
         val child2 = createChild1()
         val child3 = createChild1()
         val capturedNodes = ArrayList<Pair<Rib, Rib>>()
-        registry.whenChildrenAttached<Child1, Child1> { _, c1, c2 ->
+        registry.whenChildrenAttached<Child1, Child1>(lifecycle) { _, c1, c2 ->
             capturedNodes += c1 to c2
         }
         assertEquals(

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/childaware/ChildAwareImplTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/childaware/ChildAwareImplTest.kt
@@ -1,10 +1,12 @@
 package com.badoo.ribs.clienthelper.childaware
 
 import android.os.Parcelable
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.builder.Builder
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.Rib
 import com.badoo.ribs.core.customisation.RibCustomisationDirectoryImpl
+import com.badoo.ribs.core.lifecycle.TestLifecycle
 import com.badoo.ribs.core.modality.AncestryInfo
 import com.badoo.ribs.core.modality.BuildContext
 import com.badoo.ribs.core.modality.BuildParams
@@ -184,6 +186,35 @@ class ChildAwareImplTest {
             listOf(child1 to child2, child1 to child3, child2 to child3),
             capturedNodes
         )
+    }
+
+    // endregion
+
+    // region Callback lifecycle checks
+
+    @Test
+    fun `ignores registration when parent lifecycle is destroyed`() {
+        val testLifecycle = TestLifecycle(Lifecycle.State.DESTROYED)
+        createChild1()
+        var capturedNode: Rib? = null
+        registry.whenChildAttached<Child1>(testLifecycle.lifecycle) { _, child ->
+            capturedNode = child
+        }
+        assertNull(capturedNode)
+    }
+
+    @Test
+    fun `removes registration after parent lifecycle is destroyed`() {
+        val testLifecycle = TestLifecycle(Lifecycle.State.CREATED)
+        createChild1()
+        var capturedNode: Rib?
+        registry.whenChildAttached<Child1>(testLifecycle.lifecycle) { _, child ->
+            capturedNode = child
+        }
+        testLifecycle.state = Lifecycle.State.DESTROYED
+        capturedNode = null
+        createChild1()
+        assertNull(capturedNode)
     }
 
     // endregion

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/MinimumCombinedLifecycleTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/MinimumCombinedLifecycleTest.kt
@@ -1,9 +1,6 @@
 package com.badoo.ribs.core.lifecycle
 
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.State
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -42,19 +39,6 @@ class MinimumCombinedLifecycleTest {
         val test2 = TestLifecycle()
         val combined = MinimumCombinedLifecycle(test1.lifecycle, test2.lifecycle)
         assertEquals(State.DESTROYED, combined.lifecycle.currentState)
-    }
-
-    private class TestLifecycle : LifecycleOwner {
-        private val registry = LifecycleRegistry(this)
-
-        var state: State
-            get() = registry.currentState
-            set(value) {
-                registry.currentState = value
-            }
-
-        override fun getLifecycle(): Lifecycle = registry
-
     }
 
     companion object {

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/TestLifecycle.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/TestLifecycle.kt
@@ -1,0 +1,22 @@
+package com.badoo.ribs.core.lifecycle
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+
+class TestLifecycle() : LifecycleOwner {
+    private val registry = LifecycleRegistry(this)
+
+    constructor(state: Lifecycle.State): this() {
+        this.state = state
+    }
+
+    var state: Lifecycle.State
+        get() = registry.currentState
+        set(value) {
+            registry.currentState = value
+        }
+
+    override fun getLifecycle(): Lifecycle = registry
+
+}

--- a/libraries/rib-mvicore/src/main/java/com/badoo/ribs/mvicore/ChildAwareExt.kt
+++ b/libraries/rib-mvicore/src/main/java/com/badoo/ribs/mvicore/ChildAwareExt.kt
@@ -5,11 +5,11 @@ import com.badoo.mvicore.android.lifecycle.createDestroy
 import com.badoo.mvicore.android.lifecycle.resumePause
 import com.badoo.mvicore.android.lifecycle.startStop
 import com.badoo.mvicore.binder.Binder
-import com.badoo.ribs.clienthelper.childaware.ChildAware
+import com.badoo.ribs.clienthelper.childaware.ChildAwareDSL
 import com.badoo.ribs.core.Rib
 
-inline fun <reified T : Rib> ChildAware.createDestroy(
-    lifecycle: Lifecycle = node.lifecycle,
+inline fun <reified T : Rib> ChildAwareDSL.createDestroy(
+    lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T) -> Unit
 ) {
     whenChildAttached(lifecycle, T::class) { commonLifecycle, child ->
@@ -19,8 +19,8 @@ inline fun <reified T : Rib> ChildAware.createDestroy(
     }
 }
 
-inline fun <reified T1 : Rib, reified T2 : Rib> ChildAware.createDestroy(
-    lifecycle: Lifecycle = node.lifecycle,
+inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareDSL.createDestroy(
+    lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T1, T2) -> Unit
 ) {
     whenChildrenAttached(lifecycle, T1::class, T2::class) { commonLifecycle, child1, child2 ->
@@ -30,8 +30,8 @@ inline fun <reified T1 : Rib, reified T2 : Rib> ChildAware.createDestroy(
     }
 }
 
-inline fun <reified T : Rib> ChildAware.startStop(
-    lifecycle: Lifecycle = node.lifecycle,
+inline fun <reified T : Rib> ChildAwareDSL.startStop(
+    lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T) -> Unit
 ) {
     whenChildAttached(lifecycle, T::class) { commonLifecycle, child ->
@@ -41,8 +41,8 @@ inline fun <reified T : Rib> ChildAware.startStop(
     }
 }
 
-inline fun <reified T1 : Rib, reified T2 : Rib> ChildAware.startStop(
-    lifecycle: Lifecycle = node.lifecycle,
+inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareDSL.startStop(
+    lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T1, T2) -> Unit
 ) {
     whenChildrenAttached(lifecycle, T1::class, T2::class) { commonLifecycle, child1, child2 ->
@@ -52,8 +52,8 @@ inline fun <reified T1 : Rib, reified T2 : Rib> ChildAware.startStop(
     }
 }
 
-inline fun <reified T : Rib> ChildAware.resumePause(
-    lifecycle: Lifecycle = node.lifecycle,
+inline fun <reified T : Rib> ChildAwareDSL.resumePause(
+    lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T) -> Unit
 ) {
     whenChildAttached(lifecycle, T::class) { commonLifecycle, child ->
@@ -63,8 +63,8 @@ inline fun <reified T : Rib> ChildAware.resumePause(
     }
 }
 
-inline fun <reified T1 : Rib, reified T2 : Rib> ChildAware.resumePause(
-    lifecycle: Lifecycle = node.lifecycle,
+inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareDSL.resumePause(
+    lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T1, T2) -> Unit
 ) {
     whenChildrenAttached(lifecycle, T1::class, T2::class) { commonLifecycle, child1, child2 ->

--- a/libraries/rib-mvicore/src/main/java/com/badoo/ribs/mvicore/ChildAwareExt.kt
+++ b/libraries/rib-mvicore/src/main/java/com/badoo/ribs/mvicore/ChildAwareExt.kt
@@ -5,10 +5,10 @@ import com.badoo.mvicore.android.lifecycle.createDestroy
 import com.badoo.mvicore.android.lifecycle.resumePause
 import com.badoo.mvicore.android.lifecycle.startStop
 import com.badoo.mvicore.binder.Binder
-import com.badoo.ribs.clienthelper.childaware.ChildAwareDSL
+import com.badoo.ribs.clienthelper.childaware.ChildAwareScope
 import com.badoo.ribs.core.Rib
 
-inline fun <reified T : Rib> ChildAwareDSL.createDestroy(
+inline fun <reified T : Rib> ChildAwareScope.createDestroy(
     lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T) -> Unit
 ) {
@@ -19,7 +19,7 @@ inline fun <reified T : Rib> ChildAwareDSL.createDestroy(
     }
 }
 
-inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareDSL.createDestroy(
+inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareScope.createDestroy(
     lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T1, T2) -> Unit
 ) {
@@ -30,7 +30,7 @@ inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareDSL.createDestroy(
     }
 }
 
-inline fun <reified T : Rib> ChildAwareDSL.startStop(
+inline fun <reified T : Rib> ChildAwareScope.startStop(
     lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T) -> Unit
 ) {
@@ -41,7 +41,7 @@ inline fun <reified T : Rib> ChildAwareDSL.startStop(
     }
 }
 
-inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareDSL.startStop(
+inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareScope.startStop(
     lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T1, T2) -> Unit
 ) {
@@ -52,7 +52,7 @@ inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareDSL.startStop(
     }
 }
 
-inline fun <reified T : Rib> ChildAwareDSL.resumePause(
+inline fun <reified T : Rib> ChildAwareScope.resumePause(
     lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T) -> Unit
 ) {
@@ -63,7 +63,7 @@ inline fun <reified T : Rib> ChildAwareDSL.resumePause(
     }
 }
 
-inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareDSL.resumePause(
+inline fun <reified T1 : Rib, reified T2 : Rib> ChildAwareScope.resumePause(
     lifecycle: Lifecycle = this.lifecycle,
     noinline f: Binder.(T1, T2) -> Unit
 ) {

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/switcher/SwitcherInteractor.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/switcher/SwitcherInteractor.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Lifecycle
 import com.badoo.mvicore.android.lifecycle.startStop
 import com.badoo.mvicore.binder.using
 import com.badoo.ribs.android.dialog.Dialog
+import com.badoo.ribs.clienthelper.childaware.childAware
 import com.badoo.ribs.clienthelper.interactor.Interactor
 import com.badoo.ribs.core.modality.BuildParams
 import com.badoo.ribs.mvicore.createDestroy
@@ -97,13 +98,15 @@ internal class SwitcherInteractor(
     override fun onCreate(nodeLifecycle: Lifecycle) {
         super.onCreate(nodeLifecycle)
 
-        createDestroy<Blocker> { blocker ->
-            bind(blocker.output to blockerOutputConsumer)
-        }
+        childAware(nodeLifecycle) {
+            createDestroy<Blocker> { blocker ->
+                bind(blocker.output to blockerOutputConsumer)
+            }
 
-        createDestroy<Menu> { menu ->
-            bind(menu.output to menuListener)
-            bind(backStack.activeConfigurations.rx2() to menu.input using ConfigurationToMenuInput)
+            createDestroy<Menu> { menu ->
+                bind(menu.output to menuListener)
+                bind(backStack.activeConfigurations.rx2() to menu.input using ConfigurationToMenuInput)
+            }
         }
     }
 


### PR DESCRIPTION
The following code will:

1. Produce memory leak of `view`, because it is captured by callback, which is not removed later.
2. Be invoked twice for old and new instance of `view`.

```kotlin
override fun onViewCreated(view: View, lifecycle: Lifecycle) {
  whenChildAttached { child, commonLifecycle ->
    commonLifecycle.createDestroy { bind(view to child) }
  }
}
```

PR adds destroyed state checks (API usage correctness) and callback removal when parent lifecycle is destroyed.

TODO: Remove default lifecycle