### PR TITLE
Fix transitions for viewless containers

### DIFF
--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/ActivateAction.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/ActivateAction.kt
@@ -3,8 +3,8 @@ package com.badoo.ribs.routing.state.action.single
 import android.os.Parcelable
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.routing.Routing
-import com.badoo.ribs.routing.resolution.Resolution
 import com.badoo.ribs.routing.activator.RoutingActivator
+import com.badoo.ribs.routing.resolution.Resolution
 import com.badoo.ribs.routing.state.RoutingContext
 import com.badoo.ribs.routing.state.RoutingContext.ActivationState.ACTIVE
 import com.badoo.ribs.routing.state.RoutingContext.Resolved
@@ -30,7 +30,7 @@ internal class ActivateAction<C : Parcelable>(
     private val globalActivationLevel: RoutingContext.ActivationState
 ) : RoutingTransitionAction<C> {
 
-    object Factory: ActionFactory {
+    object Factory : ActionFactory {
         override fun <C : Parcelable> create(
             params: ActionExecutionParams<C>
         ): RoutingTransitionAction<C> =
@@ -59,7 +59,10 @@ internal class ActivateAction<C : Parcelable>(
         // The least we can do is to mark correct state, this is regardless of executing transitions
         if (!itemAlreadyActivated) {
             emitter.invoke(
-                Effect.Individual.Activated(routing, item.copy(activationState = globalActivationLevel))
+                Effect.Individual.Activated(
+                    routing,
+                    item.copy(activationState = globalActivationLevel)
+                )
             )
         }
 
@@ -72,9 +75,6 @@ internal class ActivateAction<C : Parcelable>(
     private fun prepareTransition() {
         // TODO Consider doing this closer to Router (e.g. result of RoutingActivator.activate)
         transitionElements = item.nodes.flatMap { node ->
-            /** At this point view should've been created as a consequence of [RoutingActivator.activate] */
-            if (!node.isViewless) requireNotNull(node.view)
-
             node.createTransitionElements(
                 item = item,
                 direction = TransitionDirection.ENTER,

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/ActivateAction.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/ActivateAction.kt
@@ -71,16 +71,12 @@ internal class ActivateAction<C : Parcelable>(
 
     private fun prepareTransition() {
         // TODO Consider doing this closer to Router (e.g. result of RoutingActivator.activate)
-        transitionElements = item.nodes.mapNotNull {
-            it.view?.let { ribView ->
-                TransitionElement(
-                    configuration = item.routing.configuration, // TODO consider passing the whole RoutingElement
-                    direction = TransitionDirection.ENTER,
-                    addedOrRemoved = addedOrRemoved,
-                    identifier = it.identifier,
-                    view = ribView.androidView
-                )
-            }
+        transitionElements = item.nodes.flatMap { node ->
+            node.createTransitionElements(
+                item = item,
+                direction = TransitionDirection.ENTER,
+                addedOrRemoved = addedOrRemoved,
+            )
         }
     }
 

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/ActivateAction.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/ActivateAction.kt
@@ -72,6 +72,9 @@ internal class ActivateAction<C : Parcelable>(
     private fun prepareTransition() {
         // TODO Consider doing this closer to Router (e.g. result of RoutingActivator.activate)
         transitionElements = item.nodes.flatMap { node ->
+            /** At this point view should've been created as a consequence of [RoutingActivator.activate] */
+            if (!node.isViewless) requireNotNull(node.view)
+
             node.createTransitionElements(
                 item = item,
                 direction = TransitionDirection.ENTER,

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/DeactivateAction.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/DeactivateAction.kt
@@ -51,16 +51,12 @@ internal class DeactivateAction<C : Parcelable>(
 
     override fun onBeforeTransition() {
         // TODO Consider doing this closer to Router (in result of RoutingActivator)
-        transitionElements = item.nodes.mapNotNull {
-            it.view?.let { ribView ->
-                TransitionElement(
-                    configuration = item.routing.configuration, // TODO consider passing the whole RoutingElement
-                    direction = TransitionDirection.EXIT,
-                    addedOrRemoved = addedOrRemoved,
-                    identifier = it.identifier,
-                    view = ribView.androidView
-                )
-            }
+        transitionElements = item.nodes.flatMap { node ->
+            node.createTransitionElements(
+                item = item,
+                direction = TransitionDirection.EXIT,
+                addedOrRemoved = addedOrRemoved,
+            )
         }
     }
 

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/Ext.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/Ext.kt
@@ -13,8 +13,15 @@ internal fun <C : Parcelable> Node<*>.createTransitionElements(
 ): List<TransitionElement<C>> {
     val elements = mutableListOf<TransitionElement<C>>()
 
-    val ribView = view
-    if (ribView != null) {
+    if (isViewless) {
+        children.forEach {
+            elements += it.createTransitionElements(
+                item, direction, addedOrRemoved
+            )
+        }
+    } else {
+        val ribView = view
+        requireNotNull(ribView)
         elements += TransitionElement(
             configuration = item.routing.configuration, // TODO consider passing the whole RoutingElement
             direction = direction,
@@ -22,12 +29,6 @@ internal fun <C : Parcelable> Node<*>.createTransitionElements(
             identifier = identifier,
             view = ribView.androidView
         )
-    } else {
-        children.forEach {
-            elements += it.createTransitionElements(
-                item, direction, addedOrRemoved
-            )
-        }
     }
 
     return elements

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/Ext.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/Ext.kt
@@ -1,0 +1,34 @@
+package com.badoo.ribs.routing.state.action.single
+
+import android.os.Parcelable
+import com.badoo.ribs.core.Node
+import com.badoo.ribs.routing.state.RoutingContext
+import com.badoo.ribs.routing.transition.TransitionDirection
+import com.badoo.ribs.routing.transition.TransitionElement
+
+internal fun <C : Parcelable> Node<*>.createTransitionElements(
+    item: RoutingContext.Resolved<C>,
+    direction: TransitionDirection,
+    addedOrRemoved: Boolean
+): List<TransitionElement<C>> {
+    val elements = mutableListOf<TransitionElement<C>>()
+
+    val ribView = view
+    if (ribView != null) {
+        elements += TransitionElement(
+            configuration = item.routing.configuration, // TODO consider passing the whole RoutingElement
+            direction = direction,
+            addedOrRemoved = addedOrRemoved,
+            identifier = identifier,
+            view = ribView.androidView
+        )
+    } else {
+        children.forEach {
+            elements += it.createTransitionElements(
+                item, direction, addedOrRemoved
+            )
+        }
+    }
+
+    return elements
+}

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/Ext.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/action/single/Ext.kt
@@ -20,15 +20,15 @@ internal fun <C : Parcelable> Node<*>.createTransitionElements(
             )
         }
     } else {
-        val ribView = view
-        requireNotNull(ribView)
-        elements += TransitionElement(
-            configuration = item.routing.configuration, // TODO consider passing the whole RoutingElement
-            direction = direction,
-            addedOrRemoved = addedOrRemoved,
-            identifier = identifier,
-            view = ribView.androidView
-        )
+        view?.let { ribView ->
+            elements += TransitionElement(
+                configuration = item.routing.configuration, // TODO consider passing the whole RoutingElement
+                direction = direction,
+                addedOrRemoved = addedOrRemoved,
+                identifier = identifier,
+                view = ribView.androidView
+            )
+        }
     }
 
     return elements


### PR DESCRIPTION
Symptom: viewless containers might have children with views; they're not animated in.

Fix in this ticket: recursively find transition targets from children if own Node is viewless.