### PR TITLE
Fixed animations in transition animations example when pressing back

### DIFF
--- a/samples/transition-animations/src/main/java/com/badoo/ribs/samples/transitionanimations/rib/parent/routing/ParentTransitionHandler.kt
+++ b/samples/transition-animations/src/main/java/com/badoo/ribs/samples/transitionanimations/rib/parent/routing/ParentTransitionHandler.kt
@@ -41,9 +41,8 @@ class ParentTransitionHandler(duration: Long = 1000) : TransitionHandler.Multipl
 //  addedOrRemoved property to detect when user is reversing the animation
 fun TransitionElement<out Configuration>.isNotEnteringFirstChild(): Boolean =
     !(configuration == Configuration.Child1
-        && direction == TransitionDirection.ENTER
         && addedOrRemoved)
 
 fun TransitionElement<out Configuration>.isNotExitingLastChild(): Boolean =
     !(configuration == Configuration.Child3
-        && direction == TransitionDirection.EXIT)
+        && !addedOrRemoved)

--- a/samples/transition-animations/src/main/java/com/badoo/ribs/samples/transitionanimations/rib/parent/routing/ParentTransitionHandler.kt
+++ b/samples/transition-animations/src/main/java/com/badoo/ribs/samples/transitionanimations/rib/parent/routing/ParentTransitionHandler.kt
@@ -1,7 +1,6 @@
 package com.badoo.ribs.samples.transitionanimations.rib.parent.routing
 
 import androidx.interpolator.view.animation.FastOutLinearInInterpolator
-import com.badoo.ribs.routing.transition.TransitionDirection
 import com.badoo.ribs.routing.transition.TransitionElement
 import com.badoo.ribs.routing.transition.effect.sharedelement.SharedElementTransition
 import com.badoo.ribs.routing.transition.handler.CrossFader


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
In the current implementation, the animations look weird when going back. This PR makes them look the same as the animations look when going forward but in reverse.
| Before | After |
|-------|------|
| ![back-animation-bad](https://user-images.githubusercontent.com/6322898/120648036-1fe02b00-c473-11eb-979b-9e3f6f60ef69.gif) | ![back-animation-good](https://user-images.githubusercontent.com/6322898/120648061-25d60c00-c473-11eb-85de-83af5597d002.gif) |

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
