### PR TITLE
Update Compose to 1.0-rc02 and update required dependencies

### DIFF
--- a/app-example/build.gradle
+++ b/app-example/build.gradle
@@ -27,12 +27,12 @@ def getClientSecret() {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.badoo.ribs.example"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/app-example/src/androidTest/java/com/badoo/ribs/example/TestImageLoader.kt
+++ b/app-example/src/androidTest/java/com/badoo/ribs/example/TestImageLoader.kt
@@ -1,25 +1,43 @@
 package com.badoo.ribs.example
 
 import android.content.Context
+import android.graphics.Bitmap
 import androidx.test.platform.app.InstrumentationRegistry
-import coil.DefaultRequestOptions
 import coil.ImageLoader
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
-import coil.request.GetRequest
-import coil.request.LoadRequest
-import coil.request.RequestDisposable
-import coil.request.RequestResult
+import coil.memory.MemoryCache
+import coil.request.DefaultRequestOptions
+import coil.request.Disposable
+import coil.request.ImageRequest
+import coil.request.ImageResult
 import coil.request.SuccessResult
 import com.badoo.ribs.example.test.R
 
 class TestImageLoader : ImageLoader {
 
+    override val bitmapPool: BitmapPool = BitmapPool.invoke(0)
+
+    override val memoryCache: MemoryCache = object : MemoryCache {
+        override val maxSize: Int = 0
+
+        override val size: Int = 0
+
+        override fun clear() {}
+
+        override fun get(key: MemoryCache.Key): Bitmap? = null
+
+        override fun remove(key: MemoryCache.Key): Boolean = false
+
+        override fun set(key: MemoryCache.Key, bitmap: Bitmap) {}
+    }
+
     private val instrumentationContext: Context =
-            InstrumentationRegistry.getInstrumentation().context
+        InstrumentationRegistry.getInstrumentation().context
 
     private val drawable = instrumentationContext.getDrawable(R.drawable.ic_sample)!!
 
-    private val disposable = object : RequestDisposable {
+    private val disposable = object : Disposable {
         override val isDisposed = true
         override fun dispose() {}
         override suspend fun await() {}
@@ -27,19 +45,26 @@ class TestImageLoader : ImageLoader {
 
     override val defaults = DefaultRequestOptions()
 
-    override fun execute(request: LoadRequest): RequestDisposable {
+    override fun enqueue(request: ImageRequest): Disposable {
         request.target?.onStart(drawable)
         request.target?.onSuccess(drawable)
         return disposable
     }
 
-    override suspend fun execute(request: GetRequest): RequestResult =
-        SuccessResult(drawable, DataSource.MEMORY)
+    override suspend fun execute(request: ImageRequest): ImageResult =
+        SuccessResult(
+            drawable,
+            request,
+            ImageResult.Metadata(
+                memoryCacheKey = null,
+                isSampled = false,
+                dataSource = DataSource.MEMORY,
+                isPlaceholderMemoryCacheKeyPresent = false
+            )
+        )
 
-    override fun invalidate(key: String) {}
-
-    override fun clearMemory() {}
+    override fun newBuilder(): ImageLoader.Builder =
+        ImageLoader.Builder(instrumentationContext)
 
     override fun shutdown() {}
-
 }

--- a/app-example/src/main/java/com/badoo/ribs/example/app_bar/AppBarView.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/app_bar/AppBarView.kt
@@ -3,7 +3,7 @@ package com.badoo.ribs.example.app_bar
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.annotation.LayoutRes
-import coil.api.load
+import coil.load
 import coil.transform.CircleCropTransformation
 import com.badoo.mvicore.ModelWatcher
 import com.badoo.mvicore.modelWatcher

--- a/app-example/src/main/java/com/badoo/ribs/example/feed_container/routing/FeedContainerRouter.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/feed_container/routing/FeedContainerRouter.kt
@@ -11,7 +11,7 @@ import com.badoo.ribs.routing.resolution.Resolution.Companion.noop
 import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource.Companion.permanent
 import com.badoo.ribs.routing.transition.handler.TransitionHandler
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class FeedContainerRouter internal constructor(
     buildParams: BuildParams<*>,

--- a/app-example/src/main/java/com/badoo/ribs/example/logged_in_container/routing/LoggedInContainerRouter.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/logged_in_container/routing/LoggedInContainerRouter.kt
@@ -11,7 +11,7 @@ import com.badoo.ribs.routing.resolution.Resolution
 import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource
 import com.badoo.ribs.routing.transition.handler.TransitionHandler
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class LoggedInContainerRouter internal constructor(
     buildParams: BuildParams<*>,

--- a/app-example/src/main/java/com/badoo/ribs/example/logged_out_container/routing/LoggedOutContainerRouter.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/logged_out_container/routing/LoggedOutContainerRouter.kt
@@ -11,7 +11,7 @@ import com.badoo.ribs.routing.resolution.Resolution.Companion.noop
 import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource
 import com.badoo.ribs.routing.transition.handler.TransitionHandler
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class LoggedOutContainerRouter internal constructor(
     buildParams: BuildParams<*>,

--- a/app-example/src/main/java/com/badoo/ribs/example/photo_details/PhotoDetailsView.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/photo_details/PhotoDetailsView.kt
@@ -8,7 +8,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.Group
-import coil.api.load
+import coil.load
 import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView

--- a/app-example/src/main/java/com/badoo/ribs/example/photo_details/routing/PhotoDetailsRouter.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/photo_details/routing/PhotoDetailsRouter.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.routing.resolution.Resolution.Companion.noop
 import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource
 import com.badoo.ribs.routing.transition.handler.TransitionHandler
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class PhotoDetailsRouter internal constructor(
     buildParams: BuildParams<*>,

--- a/app-example/src/main/java/com/badoo/ribs/example/photo_feed/view/PhotoListItemViewHolder.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/photo_feed/view/PhotoListItemViewHolder.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.recyclerview.widget.RecyclerView
-import coil.api.load
+import coil.load
 import com.badoo.ribs.example.R
 
 

--- a/app-example/src/main/java/com/badoo/ribs/example/root/routing/RootRouter.kt
+++ b/app-example/src/main/java/com/badoo/ribs/example/root/routing/RootRouter.kt
@@ -11,7 +11,7 @@ import com.badoo.ribs.routing.resolution.Resolution.Companion.noop
 import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource
 import com.badoo.ribs.routing.transition.handler.TransitionHandler
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class RootRouter internal constructor(
     buildParams: BuildParams<*>,

--- a/app-example/src/test/java/com/badoo/ribs/example/RxSchedulerExtension.kt
+++ b/app-example/src/test/java/com/badoo/ribs/example/RxSchedulerExtension.kt
@@ -1,0 +1,36 @@
+package com.badoo.ribs.example
+
+import io.reactivex.Scheduler
+import io.reactivex.android.plugins.RxAndroidPlugins
+import io.reactivex.functions.Function
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.Schedulers
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import java.util.concurrent.Callable
+
+class RxSchedulerExtension : AfterEachCallback, BeforeEachCallback {
+
+    private val scheduler = Schedulers.trampoline()
+    private val schedulerFunction: Function<Scheduler, Scheduler> = Function { scheduler }
+    private val schedulerFunctionLazy: Function<Callable<Scheduler>, Scheduler> =
+        Function { scheduler }
+
+    @Throws(Throwable::class)
+    override fun beforeEach(context: ExtensionContext?) {
+        RxAndroidPlugins.reset()
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler(schedulerFunctionLazy)
+
+        RxJavaPlugins.reset()
+        RxJavaPlugins.setIoSchedulerHandler(schedulerFunction)
+        RxJavaPlugins.setNewThreadSchedulerHandler(schedulerFunction)
+        RxJavaPlugins.setComputationSchedulerHandler(schedulerFunction)
+    }
+
+    @Throws(Throwable::class)
+    override fun afterEach(context: ExtensionContext?) {
+        RxAndroidPlugins.reset()
+        RxJavaPlugins.reset()
+    }
+}

--- a/app-example/src/test/java/com/badoo/ribs/example/RxSchedulerRule.kt
+++ b/app-example/src/test/java/com/badoo/ribs/example/RxSchedulerRule.kt
@@ -1,20 +1,12 @@
 package com.badoo.ribs.example
 
-import io.reactivex.Scheduler
-import io.reactivex.android.plugins.RxAndroidPlugins
-import io.reactivex.functions.Function
-import io.reactivex.plugins.RxJavaPlugins
-import io.reactivex.schedulers.Schedulers
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.util.concurrent.Callable
 
 class RxSchedulerRule : TestRule {
-    private val scheduler = Schedulers.trampoline()
-    private val schedulerFunction: Function<Scheduler, Scheduler> = Function { scheduler }
-    private val schedulerFunctionLazy: Function<Callable<Scheduler>, Scheduler> =
-        Function { scheduler }
+
+    private val extension = RxSchedulerExtension()
 
     override fun apply(
         base: Statement,
@@ -23,15 +15,9 @@ class RxSchedulerRule : TestRule {
         return object : Statement() {
             @Throws(Throwable::class)
             override fun evaluate() {
-                RxAndroidPlugins.reset()
-                RxAndroidPlugins.setInitMainThreadSchedulerHandler(schedulerFunctionLazy)
-                RxJavaPlugins.reset()
-                RxJavaPlugins.setIoSchedulerHandler(schedulerFunction)
-                RxJavaPlugins.setNewThreadSchedulerHandler(schedulerFunction)
-                RxJavaPlugins.setComputationSchedulerHandler(schedulerFunction)
+                extension.beforeEach(null)
                 base.evaluate()
-                RxAndroidPlugins.reset()
-                RxJavaPlugins.reset()
+                extension.afterEach(null)
             }
         }
     }

--- a/app-example/src/test/java/com/badoo/ribs/example/root/RootInteractorAuthStateTest.kt
+++ b/app-example/src/test/java/com/badoo/ribs/example/root/RootInteractorAuthStateTest.kt
@@ -1,7 +1,7 @@
 package com.badoo.ribs.example.root
 
 import androidx.lifecycle.Lifecycle
-import com.badoo.ribs.example.RxSchedulerRule
+import com.badoo.ribs.example.RxSchedulerExtension
 import com.badoo.ribs.example.auth.AuthDataSource
 import com.badoo.ribs.example.auth.AuthState
 import com.badoo.ribs.example.root.routing.RootRouter.Configuration
@@ -14,17 +14,16 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.BeforeEach
-import org.junit.Rule
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
+@ExtendWith(RxSchedulerExtension::class)
 class RootInteractorAuthStateTest {
 
     private val backStack: BackStack<Configuration> = mock()
-    @get:Rule
-    val rxSchedulerRule = RxSchedulerRule()
 
     private val stateRelay = PublishRelay.create<AuthState>()
     private val authDataSource = mock<AuthDataSource>().apply {

--- a/app-example/src/test/java/com/badoo/ribs/example/welcome/WelcomeInteractorTest.kt
+++ b/app-example/src/test/java/com/badoo/ribs/example/welcome/WelcomeInteractorTest.kt
@@ -13,8 +13,8 @@ import com.jakewharton.rxrelay2.Relay
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import io.reactivex.observers.TestObserver
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class WelcomeInteractorTest {
 
@@ -26,7 +26,7 @@ class WelcomeInteractorTest {
     private val output = PublishRelay.create<Output>()
 
 
-    @Before
+    @BeforeEach
     fun setup() {
         interactor = WelcomeInteractor(
             buildParams = emptyBuildParams(),

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ buildscript {
     apply from: 'gradle/dependencies.gradle'
 
     repositories {
-        jcenter()
         google()
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -28,9 +27,8 @@ apply from: 'gradle/utils.gradle'
 subprojects {
     buildscript {
         repositories {
-            jcenter()
             maven { url deps.build.gradlePluginsUrl }
-            maven { url "https://maven.google.com" }
+            google()
             maven { url "https://plugins.gradle.org/m2/" }
 
             maven {
@@ -40,15 +38,8 @@ subprojects {
     }
 
     repositories {
-        jcenter {
-            content {
-                // just allow to include kotlinx projects
-                // detekt needs 'kotlinx-html' for the html report
-                includeGroup "org.jetbrains.kotlinx"
-            }
-        }
         maven { url deps.build.gradlePluginsUrl }
-        maven { url "https://maven.google.com" }
+        google()
         maven { url "https://www.jitpack.io" }
 
         maven {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,20 +9,21 @@ apply from: "$rootDirectory/gradle/compose.gradle"
 
 def kotlinVersion
 if (useCompose.toBoolean()) {
-    kotlinVersion = '1.4.30'
+    kotlinVersion = '1.5.21'
 } else {
     kotlinVersion = '1.4.31'
 }
 println("kotlin version: $kotlinVersion")
 
 def versions = [
-        dagger                         : '2.22.1',
+        dagger                         : '2.37',
         intellij                       : '2020.1.4',
         intellij_kotlin                : '1.3.72-release-IJ2020.1-1',
         kotlin                         : kotlinVersion,
         mviCore                        : '1.2.4',
-        robolectric                    : '4.4',
-        compose                        : '1.0.0-beta01',
+        robolectric                    : '4.6.1',
+        compose                        : '1.0.0-rc02',
+        kotlinComposeCompilerVersion   : '1.5.10', // https://developer.android.com/jetpack/androidx/releases/compose-runtime#declaring_dependencies
 
         materialVersion                : '1.1.0', // https://github.com/material-components/material-components-android/releases
         androidxAnnotationVersion      : '1.1.0', // https://developer.android.com/jetpack/androidx/releases/annotation
@@ -32,12 +33,12 @@ def versions = [
         androidxCardViewVersion        : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/cardview
         androidxCollectionVersion      : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/collection
         androidxConstraintLayoutVersion: '1.1.3', // https://developer.android.com/jetpack/androidx/releases/constraintlayout & https://androidstudio.googleblog.com/
-        androidxCoreVersion            : '1.3.0', // https://developer.android.com/jetpack/androidx/releases/core
+        androidxCoreVersion            : useCompose.toBoolean() ? '1.5.0' : '1.3.0', // https://developer.android.com/jetpack/androidx/releases/core
         androidxExifVersion            : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/exifinterface
-        androidxFragmentVersion        : '1.1.0', // https://developer.android.com/jetpack/androidx/releases/fragment
-        androidxActivityVersion        : '1.1.0', // https://developer.android.com/jetpack/androidx/releases/activity
+        androidxFragmentVersion        : useCompose.toBoolean() ? '1.3.5' : '1.1.0', // https://developer.android.com/jetpack/androidx/releases/fragment
+        androidxActivityVersion        : useCompose.toBoolean() ? '1.2.3' : '1.1.0', // https://developer.android.com/jetpack/androidx/releases/activity
         androidxGridLayoutVersion      : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/gridlayout
-        androidxLifecycleVersion       : '2.0.0', // https://developer.android.com/jetpack/androidx/releases/lifecycle
+        androidxLifecycleVersion       : useCompose.toBoolean() ? '2.3.1' : '2.0.0', // https://developer.android.com/jetpack/androidx/releases/lifecycle
         androidxLoaderVersion          : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/loader
         androidxPaletteVersion         : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/palette
         androidxPercentLayoutVersion   : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/percentlayout
@@ -51,26 +52,26 @@ def versions = [
         junit5                         : '5.7.1'
 ]
 
+println("androidxCoreVersion version: ${versions.androidxCoreVersion}")
+println("androidxFragmentVersion version: ${versions.androidxFragmentVersion}")
+println("androidxActivityVersion version: ${versions.androidxActivityVersion}")
+println("androidxLifecycleVersion version: ${versions.androidxLifecycleVersion}")
+
 def apt = [
-    daggerCompiler: "com.google.dagger:dagger-compiler:${versions.dagger}",
-    javax: "javax.annotation:jsr250-api:1.0",
-    javaxInject: "javax.inject:javax.inject:1",
+        daggerCompiler: "com.google.dagger:dagger-compiler:${versions.dagger}",
+        javax         : "javax.annotation:jsr250-api:1.0",
+        javaxInject   : "javax.inject:javax.inject:1",
 ]
 
-def agp
-if (useCompose.toBoolean()) {
-    agp = 'com.android.tools.build:gradle:7.0.0-alpha08'
-} else {
-    agp = 'com.android.tools.build:gradle:4.1.1'
-}
+def agp = 'com.android.tools.build:gradle:4.2.2'
 println("agp version: $agp")
 
 def build = [
-        compileSdkVersion: 28,
+        compileSdkVersion: 30,
         gradlePluginsUrl : "https://plugins.gradle.org/m2/",
         ci               : 'true' == System.getenv('CI'),
         minSdkVersion    : 17,
-        targetSdkVersion : 28,
+        targetSdkVersion : 30,
         guava            : "com.google.guava:guava:20.0",
         commonsLang      : "commons-lang:commons-lang:2.6",
         intellijPlugin   : "org.jetbrains.intellij:org.jetbrains.intellij.gradle.plugin:0.7.3",
@@ -80,7 +81,7 @@ def build = [
                 kotlin         : "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
                 gradleKotlinDsl: 'org.gradle.kotlin:plugins:1.2.2',
                 mavenPublish   : 'com.vanniktech:gradle-maven-publish-plugin:0.15.1',
-                detekt         : 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.10.0',
+                detekt         : 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1',
                 jacoco         : "org.jacoco:org.jacoco.core:${versions.jacoco}"
         ]
 ]
@@ -100,11 +101,12 @@ def android = [
 ]
 
 def compose = [
-        runtime   : "androidx.compose.runtime:runtime:${versions.compose}",
-        ui        : "androidx.compose.ui:ui:${versions.compose}",
-        material  : "androidx.compose.material:material:${versions.compose}",
-        uiTooling : "androidx.compose.ui:ui-tooling:${versions.compose}",
-        foundation: "androidx.compose.foundation:foundation:${versions.compose}"
+        runtime         : "androidx.compose.runtime:runtime:${versions.compose}",
+        ui              : "androidx.compose.ui:ui:${versions.compose}",
+        material        : "androidx.compose.material:material:${versions.compose}",
+        uiTooling       : "androidx.compose.ui:ui-tooling:${versions.compose}",
+        uiToolingPreview: "androidx.compose.ui:ui-tooling-preview:${versions.compose}",
+        foundation      : "androidx.compose.foundation:foundation:${versions.compose}"
 ]
 
 def test = [
@@ -128,7 +130,7 @@ def androidTest = [
 ]
 
 def external = [
-        kotlinStdlib    : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
+        kotlinStdlib    : "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
         dagger          : "com.google.dagger:dagger:${versions.dagger}",
         mviCore         : "com.github.badoo.mvicore:mvicore:${versions.mviCore}",
         mviCoreAndroid  : "com.github.badoo.mvicore:mvicore-android:${versions.mviCore}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,6 +27,7 @@ def versions = [
         materialVersion                : '1.1.0', // https://github.com/material-components/material-components-android/releases
         androidxAnnotationVersion      : '1.1.0', // https://developer.android.com/jetpack/androidx/releases/annotation
         androidxAppCompatVersion       : '1.1.0', // https://developer.android.com/jetpack/androidx/releases/appcompat
+        androidxArchCoreVersion        : '2.1.0', // https://developer.android.com/jetpack/androidx/releases/arch-core
         androidxBrowserVersion         : '1.3.0', // https://developer.android.com/jetpack/androidx/releases/browser
         androidxBroadcastVersion       : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/localbroadcastmanager
         androidxCardViewVersion        : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/cardview
@@ -56,6 +57,7 @@ println("androidxCoreVersion version: ${versions.androidxCoreVersion}")
 println("androidxFragmentVersion version: ${versions.androidxFragmentVersion}")
 println("androidxActivityVersion version: ${versions.androidxActivityVersion}")
 println("androidxLifecycleVersion version: ${versions.androidxLifecycleVersion}")
+println("coil version: ${versions.coil}")
 
 def apt = [
         daggerCompiler: "com.google.dagger:dagger-compiler:${versions.dagger}",
@@ -64,7 +66,6 @@ def apt = [
 ]
 
 def agp = 'com.android.tools.build:gradle:4.2.2'
-println("agp version: $agp")
 
 def build = [
         compileSdkVersion: 30,
@@ -98,7 +99,8 @@ def android = [
         rules           : "androidx.test:rules:${versions.androidxTestVersion}",
         activity        : "androidx.activity:activity-ktx:${versions.androidxActivityVersion}",
         fragment        : "androidx.fragment:fragment-ktx:${versions.androidxFragmentVersion}",
-        browser         : "androidx.browser:browser:${versions.androidxBrowserVersion}"
+        browser         : "androidx.browser:browser:${versions.androidxBrowserVersion}",
+        archCoreTesting : "androidx.arch.core:core-testing:${versions.androidxArchCoreVersion}"
 ]
 
 def compose = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -49,7 +49,8 @@ def versions = [
         okhttp                         : '3.14.7',
         leakCanary                     : '2.4',
         jacoco                         : '0.8.6',
-        junit5                         : '5.7.1'
+        junit5                         : '5.7.1',
+        coil                           : useCompose.toBoolean() ? '1.2.2' : '1.2.0'
 ]
 
 println("androidxCoreVersion version: ${versions.androidxCoreVersion}")
@@ -144,7 +145,7 @@ def external = [
         leakcanaryDebug : 'com.squareup.leakcanary:leakcanary-android:1.6.3',
         apacheCommons   : 'org.apache.commons:commons-lang3:3.0',
         gson            : 'com.google.code.gson:gson:2.8.5',
-        coil            : 'io.coil-kt:coil:0.11.0',
+        coil            : "io.coil-kt:coil:${versions.coil}",
         leakCanary      : "com.squareup.leakcanary:leakcanary-android:${versions.leakCanary}"
 ]
 
@@ -154,7 +155,7 @@ def retrofit = [
         moshiConverter          : "com.squareup.retrofit2:converter-moshi:${versions.retrofitVersion}",
         okhttp                  : "com.squareup.okhttp3:okhttp:${versions.okhttp}",
         okhttpLoggingInterceptor: "com.squareup.okhttp3:logging-interceptor:${versions.okhttp}",
-        moshiKotlin : "com.squareup.moshi:moshi-kotlin:1.11.0",
+        moshiKotlin             : "com.squareup.moshi:moshi-kotlin:1.11.0",
 ]
 
 ext.deps = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ apply from: "$rootDirectory/gradle/compose.gradle"
 
 def kotlinVersion
 if (useCompose.toBoolean()) {
-    kotlinVersion = '1.5.21'
+    kotlinVersion = '1.5.10' // https://mvnrepository.com/artifact/androidx.compose.runtime/runtime/1.0.0-rc02
 } else {
     kotlinVersion = '1.4.31'
 }
@@ -23,7 +23,6 @@ def versions = [
         mviCore                        : '1.2.6',
         robolectric                    : '4.6.1',
         compose                        : '1.0.0-rc02',
-        kotlinComposeCompilerVersion   : '1.5.10', // https://developer.android.com/jetpack/androidx/releases/compose-runtime#declaring_dependencies
 
         materialVersion                : '1.1.0', // https://github.com/material-components/material-components-android/releases
         androidxAnnotationVersion      : '1.1.0', // https://developer.android.com/jetpack/androidx/releases/annotation

--- a/gradle/utils.gradle
+++ b/gradle/utils.gradle
@@ -1,14 +1,14 @@
 ext.configureAndroidLibrary = { project ->
     project.apply plugin: 'com.android.library'
     project.apply plugin: 'kotlin-android'
-    project.apply plugin: 'kotlin-android-extensions'
+    project.apply plugin: 'kotlin-parcelize'
     configureAndroidModule(project)
 }
 
 ext.configureAndroidApp = { project ->
     project.apply plugin: 'com.android.application'
     project.apply plugin: 'kotlin-android'
-    project.apply plugin: 'kotlin-android-extensions'
+    project.apply plugin: 'kotlin-parcelize'
     configureAndroidModule(project)
 }
 
@@ -76,7 +76,10 @@ private def configureAndroidModule(Project project) {
             animationsDisabled true
             unitTests {
                 includeAndroidResources = true
-                all { useJUnitPlatform() }
+                all {
+                    useJUnitPlatform()
+                    systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
+                }
             }
         }
 

--- a/gradle/utils.gradle
+++ b/gradle/utils.gradle
@@ -31,13 +31,14 @@ ext.configureDetektForAllSubprojects = { Project project ->
     }
 }
 
-ext.junitTestImplementation = { project ->
-    project.dependencies {
+ext.junitTestImplementation = { it ->
+    it.dependencies {
         testImplementation deps.test.junitApi
         testImplementation deps.test.junitParams
         testRuntimeOnly deps.test.junitEngine
         testImplementation deps.test.junitVintage
         testImplementation deps.test.byteBuddy
+        testImplementation project(':internal:junitextensions')
     }
 }
 

--- a/internal/junitextensions/build.gradle
+++ b/internal/junitextensions/build.gradle
@@ -1,0 +1,8 @@
+configureAndroidLibrary(project)
+
+apply from: rootProject.file('gradle/code-coverage.gradle')
+
+dependencies {
+    implementation deps.test.junitApi
+    implementation deps.android.archCoreTesting
+}

--- a/internal/junitextensions/build.gradle
+++ b/internal/junitextensions/build.gradle
@@ -6,3 +6,9 @@ dependencies {
     implementation deps.test.junitApi
     implementation deps.android.archCoreTesting
 }
+
+android {
+    packagingOptions {
+        exclude 'META-INF/LICENSE*.*'
+    }
+}

--- a/internal/junitextensions/src/main/AndroidManifest.xml
+++ b/internal/junitextensions/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest package="com.badoo.ribs.internal.junitextensions">
+
+</manifest>

--- a/internal/junitextensions/src/main/java/com/badoo/ribs/internal/junitextensions/AndroidXArchCoreExtension.kt
+++ b/internal/junitextensions/src/main/java/com/badoo/ribs/internal/junitextensions/AndroidXArchCoreExtension.kt
@@ -1,4 +1,4 @@
-package com.badoo.ribs.test
+package com.badoo.ribs.internal.junitextensions
 
 import android.annotation.SuppressLint
 import androidx.arch.core.executor.ArchTaskExecutor

--- a/internal/junitextensions/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/internal/junitextensions/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.badoo.ribs.internal.junitextensions.AndroidXArchCoreExtension

--- a/libraries/rib-base-test/build.gradle
+++ b/libraries/rib-base-test/build.gradle
@@ -15,7 +15,6 @@ android {
 }
 
 dependencies {
-    compileOnly deps.test.junitApi
     compileOnly project(':libraries:rib-base')
 
     implementation deps.test.mockito

--- a/libraries/rib-base-test/build.gradle
+++ b/libraries/rib-base-test/build.gradle
@@ -15,6 +15,7 @@ android {
 }
 
 dependencies {
+    compileOnly deps.test.junitApi
     compileOnly project(':libraries:rib-base')
 
     implementation deps.test.mockito

--- a/libraries/rib-base-test/src/main/java/com/badoo/ribs/test/AndroidXArchCoreExtension.kt
+++ b/libraries/rib-base-test/src/main/java/com/badoo/ribs/test/AndroidXArchCoreExtension.kt
@@ -1,0 +1,39 @@
+package com.badoo.ribs.test
+
+import android.annotation.SuppressLint
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.arch.core.executor.TaskExecutor
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Rule to remove the main thread checks from AndroidX Arch Components.
+ *
+ * We can't use [androidx.arch.core.executor.testing.InstantTaskExecutorRule] with JUnit5 so copy-paste it here.
+ */
+@SuppressLint("RestrictedApi")
+class AndroidXArchCoreExtension : BeforeAllCallback, AfterAllCallback {
+
+    override fun beforeAll(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(object : TaskExecutor() {
+
+            override fun executeOnDiskIO(runnable: Runnable) {
+                runnable.run()
+            }
+
+            override fun postToMainThread(runnable: Runnable) {
+                runnable.run()
+            }
+
+            override fun isMainThread(): Boolean =
+                true
+
+        })
+    }
+
+    override fun afterAll(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(null)
+    }
+
+}

--- a/libraries/rib-base-test/src/main/java/com/badoo/ribs/test/interactor/RibInteractorTestHelper.kt
+++ b/libraries/rib-base-test/src/main/java/com/badoo/ribs/test/interactor/RibInteractorTestHelper.kt
@@ -14,7 +14,7 @@ import com.badoo.ribs.routing.Routing
 import com.badoo.ribs.test.RibTestHelper
 import com.badoo.ribs.test.integrationpoint.TestIntegrationPoint
 import com.badoo.ribs.test.node.RibNodeTestHelper
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class RibInteractorTestHelper<out R : Rib, View : RibView>(
     val interactor: Interactor<*, View>,

--- a/libraries/rib-base-test/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/libraries/rib-base-test/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,0 @@
-com.badoo.ribs.test.AndroidXArchCoreExtension

--- a/libraries/rib-base-test/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/libraries/rib-base-test/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.badoo.ribs.test.AndroidXArchCoreExtension

--- a/libraries/rib-base/build.gradle
+++ b/libraries/rib-base/build.gradle
@@ -1,11 +1,6 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android-extensions'
 apply from: rootProject.file('gradle/code-coverage.gradle')
-
-androidExtensions {
-    experimental = true
-}
 
 dependencies {
     api deps.android.appCompat
@@ -21,7 +16,6 @@ dependencies {
 
     junitTestImplementation(project)
     testImplementation deps.android.annotations
-    testImplementation deps.test.mockito
     testImplementation deps.test.assertj
     testImplementation deps.external.roboelectricBase
     testImplementation deps.test.mockitoKotlin

--- a/libraries/rib-base/src/androidTest/java/com/badoo/ribs/test/util/ribs/child/TestChildRouter.kt
+++ b/libraries/rib-base/src/androidTest/java/com/badoo/ribs/test/util/ribs/child/TestChildRouter.kt
@@ -7,7 +7,7 @@ import com.badoo.ribs.routing.resolution.Resolution
 import com.badoo.ribs.routing.Routing
 import com.badoo.ribs.routing.source.impl.Empty
 import com.badoo.ribs.test.util.ribs.child.TestChildRouter.Configuration
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class TestChildRouter(
     buildParams: BuildParams<Nothing?>

--- a/libraries/rib-base/src/androidTest/java/com/badoo/ribs/test/util/ribs/root/TestRootRouter.kt
+++ b/libraries/rib-base/src/androidTest/java/com/badoo/ribs/test/util/ribs/root/TestRootRouter.kt
@@ -17,7 +17,7 @@ import com.badoo.ribs.routing.transition.handler.TransitionHandler
 import com.badoo.ribs.test.util.ribs.TestRibDialog
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration
 import com.badoo.ribs.test.util.ribs.root.TestRootRouter.Configuration.*
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class TestRootRouter(
     buildParams: BuildParams<*>,

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/Routing.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/Routing.kt
@@ -1,7 +1,7 @@
 package com.badoo.ribs.routing
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.io.Serializable
 
 

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/history/RoutingHistoryElement.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/history/RoutingHistoryElement.kt
@@ -3,7 +3,7 @@ package com.badoo.ribs.routing.history
 import android.os.Parcelable
 import com.badoo.ribs.routing.Routing
 import com.badoo.ribs.routing.history.RoutingHistoryElement.Activation.INACTIVE
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Marks a [Routing] with [Activation] status, and lists

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/source/backstack/BackStack.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/source/backstack/BackStack.kt
@@ -19,7 +19,7 @@ import com.badoo.ribs.routing.source.backstack.operation.Remove
 import com.badoo.ribs.routing.source.backstack.operation.canPop
 import com.badoo.ribs.routing.source.backstack.operation.canPopOverlay
 import com.badoo.ribs.routing.source.backstack.operation.pop
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import kotlin.random.Random
 
 private val timeCapsuleKey = BackStack::class.java.name

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/RoutingContext.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/RoutingContext.kt
@@ -11,7 +11,7 @@ import com.badoo.ribs.routing.resolution.Resolution
 import com.badoo.ribs.routing.resolver.RoutingResolver
 import com.badoo.ribs.routing.state.RoutingContext.ActivationState.ACTIVE
 import com.badoo.ribs.util.RIBs
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Holds persistent (activation level) and disposable (e.g. resolved Nodes) extra information

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/PendingTransition.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/PendingTransition.kt
@@ -1,6 +1,7 @@
 package com.badoo.ribs.routing.state.feature
 
 import android.os.Handler
+import android.os.Looper
 import android.os.Parcelable
 import android.view.View
 import com.badoo.ribs.routing.state.action.single.ReversibleAction
@@ -17,7 +18,7 @@ internal class PendingTransition<C : Parcelable>(
     private val transitionElements: List<TransitionElement<C>>,
     private val effectEmitter: EffectEmitter<C>,
     private val internalTransactionConsumer: InternalTransactionConsumer<C>,
-    private val handler: Handler = Handler()
+    private val handler: Handler = Handler(Looper.getMainLooper())
 ) {
 
     fun schedule() {

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/state/SavedState.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/state/feature/state/SavedState.kt
@@ -3,7 +3,7 @@ package com.badoo.ribs.routing.state.feature.state
 import android.os.Parcelable
 import com.badoo.ribs.routing.Routing
 import com.badoo.ribs.routing.state.RoutingContext
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * The state of [RoutingStatePool] in a form that can be persisted to [android.os.Bundle].

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/childaware/ChildAwareImplTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/childaware/ChildAwareImplTest.kt
@@ -12,11 +12,11 @@ import com.badoo.ribs.core.modality.BuildContext
 import com.badoo.ribs.core.modality.BuildParams
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.routing.Routing
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ChildAwareImplTest {
 

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/connector/ConnectableNodeTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/connector/ConnectableNodeTest.kt
@@ -9,9 +9,9 @@ import com.badoo.ribs.core.helper.connectable.ConnectableTestRib
 import com.badoo.ribs.core.helper.connectable.ConnectableTestRib.Output.Output1
 import com.badoo.ribs.core.helper.connectable.ConnectableTestRib.Output.Output2
 import io.reactivex.observers.TestObserver
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 
 class ConnectableNodeTest : BaseConnectableNodeTest() {
@@ -26,12 +26,12 @@ class ConnectableNodeTest : BaseConnectableNodeTest() {
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         parent = TestNode(viewFactory = null, plugins = listOf(changesAwarePlugin))
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         testObserver.dispose()
     }

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/AnyConfiguration.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/AnyConfiguration.kt
@@ -1,7 +1,7 @@
 package com.badoo.ribs.core.helper
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 object AnyConfiguration : Parcelable { override fun toString(): String = "AnyConfiguration" }

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestRouter.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestRouter.kt
@@ -7,7 +7,7 @@ import com.badoo.ribs.routing.resolution.Resolution
 import com.badoo.ribs.routing.source.backstack.BackStack
 import com.badoo.ribs.routing.Routing
 import com.nhaarman.mockitokotlin2.mock
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class TestRouter(
     buildParams: BuildParams<Nothing?> = testBuildParams(),

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/CappedLifecycleTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/CappedLifecycleTest.kt
@@ -10,8 +10,8 @@ import androidx.lifecycle.LifecycleRegistry
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class CappedLifecycleTest {
 
@@ -19,7 +19,7 @@ class CappedLifecycleTest {
 
     private val lifecycleRegistry = mock<LifecycleRegistry>()
 
-    @Before
+    @BeforeEach
     fun setUp() {
         cappedLifecycle = CappedLifecycle(lifecycleRegistry)
     }

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/LifecycleManagerTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/LifecycleManagerTest.kt
@@ -10,8 +10,8 @@ import com.badoo.ribs.routing.Routing
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
 
 class LifecycleManagerTest {
@@ -22,7 +22,7 @@ class LifecycleManagerTest {
         on { children } doReturn children
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         lifecycleManager = LifecycleManager(owner)
     }

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/MinimumCombinedLifecycleTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/lifecycle/MinimumCombinedLifecycleTest.kt
@@ -2,7 +2,7 @@ package com.badoo.ribs.core.lifecycle
 
 import androidx.lifecycle.Lifecycle.State
 import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class MinimumCombinedLifecycleTest {
 

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/routing/source/backstack/BackStackTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/routing/source/backstack/BackStackTest.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import com.badoo.ribs.minimal.reactive.Source
 import com.badoo.ribs.routing.source.backstack.operation.push
 import com.badoo.ribs.test.emptyBuildParams
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/routing/state/RoutingStatePoolTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/routing/state/RoutingStatePoolTest.kt
@@ -24,7 +24,7 @@ import com.badoo.ribs.routing.state.feature.Transaction.PoolCommand.Sleep
 import com.badoo.ribs.routing.state.feature.Transaction.PoolCommand.WakeUp
 import com.badoo.ribs.routing.state.feature.state.SavedState
 import com.nhaarman.mockitokotlin2.*
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Ignore

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/routing/state/feature/ActorTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/routing/state/feature/ActorTest.kt
@@ -154,7 +154,7 @@ internal class ActorTest {
     companion object {
 
         @JvmStatic
-        private fun scheduleTestArguments(): Stream<Arguments> = Stream.of(
+        fun scheduleTestArguments(): Stream<Arguments> = Stream.of(
             createScheduleTestArguments(
                 activationState = ACTIVE,
                 transitionHandler = mock(),
@@ -179,7 +179,7 @@ internal class ActorTest {
             Arguments.of(activationState, transitionHandler, isScheduled)
 
         @JvmStatic
-        private fun pendingInteractionsTestArguments(): Stream<Arguments> = Stream.of(
+        fun pendingInteractionsTestArguments(): Stream<Arguments> = Stream.of(
             interactionTestArguments(
                 isContinuation = false,
                 isReversed = true),
@@ -195,7 +195,7 @@ internal class ActorTest {
             Arguments.of(isContinuation, isReversed)
 
         @JvmStatic
-        private fun executePendingTestArguments() =
+        fun executePendingTestArguments() =
             Stream.of(
                 createExecutePendingTestArguments(
                     activationState = ACTIVE,
@@ -249,7 +249,7 @@ internal class ActorTest {
         }
 
         @JvmStatic
-        private fun ongoingTransitionInteractionsTestArguments() =
+        fun ongoingTransitionInteractionsTestArguments() =
             Stream.of(
                 interactionTestArguments(isContinuation = false, isReversed = false),
                 interactionTestArguments(isContinuation = true, isReversed = false),

--- a/libraries/rib-compose/build.gradle
+++ b/libraries/rib-compose/build.gradle
@@ -29,7 +29,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion deps.versions.kotlinComposeCompilerVersion
+        kotlinCompilerVersion deps.versions.kotlin
         kotlinCompilerExtensionVersion deps.versions.compose
     }
 }

--- a/libraries/rib-compose/build.gradle
+++ b/libraries/rib-compose/build.gradle
@@ -1,12 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android-extensions'
-
-androidExtensions {
-    experimental = true
-    features = ["parcelize"]
-}
-
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=com.badoo.ribs.annotation.ExperimentalApi"
@@ -15,11 +8,11 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
@@ -36,7 +29,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion deps.versions.kotlin
+        kotlinCompilerVersion deps.versions.kotlinComposeCompilerVersion
         kotlinCompilerExtensionVersion deps.versions.compose
     }
 }
@@ -48,6 +41,7 @@ dependencies {
     implementation deps.compose.ui
     implementation deps.compose.material
     implementation deps.compose.uiTooling
+    debugImplementation deps.compose.uiToolingPreview
     implementation deps.compose.foundation
 
     implementation project(":libraries:rib-base")

--- a/libraries/rib-portal-rx2/build.gradle
+++ b/libraries/rib-portal-rx2/build.gradle
@@ -1,11 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android-extensions'
-
-androidExtensions {
-    experimental = true
-}
-
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=com.badoo.ribs.annotation.ExperimentalApi"
@@ -28,7 +22,6 @@ dependencies {
 
     junitTestImplementation(project)
     testImplementation deps.android.annotations
-    testImplementation deps.test.mockito
     testImplementation deps.test.assertj
     testImplementation deps.external.roboelectricBase
     testImplementation deps.test.mockitoKotlin

--- a/libraries/rib-portal-rx2/src/main/java/com/badoo/ribs/portal/rx2/Rx2PortalNode.kt
+++ b/libraries/rib-portal-rx2/src/main/java/com/badoo/ribs/portal/rx2/Rx2PortalNode.kt
@@ -1,5 +1,6 @@
 package com.badoo.ribs.portal.rx2
 
+import com.badoo.ribs.annotation.ExperimentalApi
 import com.badoo.ribs.core.Rib
 import com.badoo.ribs.core.modality.AncestryInfo
 import com.badoo.ribs.core.modality.BuildParams
@@ -11,6 +12,7 @@ import com.badoo.ribs.routing.source.backstack.operation.push
 import com.badoo.ribs.rx2.workflows.RxWorkflowNode
 import io.reactivex.Single
 
+@ExperimentalApi
 internal class Rx2PortalNode(
     buildParams: BuildParams<*>,
     private val backStack: BackStack<Configuration>,

--- a/libraries/rib-portal/build.gradle
+++ b/libraries/rib-portal/build.gradle
@@ -1,11 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android-extensions'
-
-androidExtensions {
-    experimental = true
-}
-
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=com.badoo.ribs.annotation.ExperimentalApi"
@@ -22,7 +16,6 @@ dependencies {
 
     junitTestImplementation(project)
     testImplementation deps.android.annotations
-    testImplementation deps.test.mockito
     testImplementation deps.test.assertj
     testImplementation deps.external.roboelectricBase
     testImplementation deps.test.mockitoKotlin

--- a/libraries/rib-portal/src/main/java/com/badoo/ribs/portal/PortalRouter.kt
+++ b/libraries/rib-portal/src/main/java/com/badoo/ribs/portal/PortalRouter.kt
@@ -16,7 +16,7 @@ import com.badoo.ribs.routing.resolver.RoutingResolver
 import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource
 import com.badoo.ribs.routing.transition.handler.TransitionHandler
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @ExperimentalApi
 class PortalRouter(

--- a/libraries/rib-portal/src/test/java/com/badoo/ribs/portal/TestRouter.kt
+++ b/libraries/rib-portal/src/test/java/com/badoo/ribs/portal/TestRouter.kt
@@ -8,7 +8,7 @@ import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.backstack.BackStack
 import com.badoo.ribs.test.emptyBuildParams
 import com.nhaarman.mockitokotlin2.mock
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class TestRouter(
     buildParams: BuildParams<Nothing?> = emptyBuildParams(),

--- a/libraries/rib-recyclerview/build.gradle
+++ b/libraries/rib-recyclerview/build.gradle
@@ -1,11 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android-extensions'
-
-androidExtensions {
-    experimental = true
-}
-
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         freeCompilerArgs += "-Xopt-in=com.badoo.ribs.annotation.ExperimentalApi"
@@ -28,7 +22,6 @@ dependencies {
 
     junitTestImplementation(project)
     testImplementation deps.android.annotations
-    testImplementation deps.test.mockito
     testImplementation deps.test.assertj
     testImplementation deps.external.roboelectricBase
     testImplementation deps.test.mockitoKotlin

--- a/libraries/rib-recyclerview/src/main/java/com/badoo/ribs/android/recyclerview/RecyclerViewHost.kt
+++ b/libraries/rib-recyclerview/src/main/java/com/badoo/ribs/android/recyclerview/RecyclerViewHost.kt
@@ -9,7 +9,7 @@ import com.badoo.ribs.rx2.clienthelper.connector.Connectable
 import com.badoo.ribs.annotation.ExperimentalApi
 import com.badoo.ribs.core.Rib
 import com.badoo.ribs.routing.resolver.RoutingResolver
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @ExperimentalApi
 interface RecyclerViewHost<T : Parcelable>: Rib, Connectable<Input<T>, Nothing> {

--- a/libraries/rib-recyclerview/src/main/java/com/badoo/ribs/android/recyclerview/RecyclerViewHostFeature.kt
+++ b/libraries/rib-recyclerview/src/main/java/com/badoo/ribs/android/recyclerview/RecyclerViewHostFeature.kt
@@ -9,7 +9,7 @@ import com.badoo.ribs.android.recyclerview.RecyclerViewHost.Input
 import com.badoo.ribs.android.recyclerview.RecyclerViewHostFeature.State
 import com.badoo.ribs.routing.Routing
 import io.reactivex.Observable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.*
 
 private val timeCapsuleKey = "RecyclerViewHostFeature"

--- a/libraries/rib-rx2/build.gradle
+++ b/libraries/rib-rx2/build.gradle
@@ -1,11 +1,5 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android-extensions'
-
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     api deps.external.rxrelay2
     api deps.external.rxjava2
@@ -14,7 +8,6 @@ dependencies {
 
     junitTestImplementation(project)
     testImplementation deps.android.annotations
-    testImplementation deps.test.mockito
     testImplementation deps.test.assertj
     testImplementation deps.external.roboelectricBase
     testImplementation deps.test.mockitoKotlin

--- a/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/DisposablePluginTest.kt
+++ b/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/DisposablePluginTest.kt
@@ -6,15 +6,15 @@ import com.badoo.ribs.core.modality.BuildParams
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import io.reactivex.disposables.Disposable
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DisposablePluginTest {
 
     private val disposables = mock<Disposable>()
     private lateinit var node: Node<*>
 
-    @Before
+    @BeforeEach
     fun setUp() {
         node = Node<Nothing>(
             buildParams = BuildParams(null, BuildContext.root(null)),

--- a/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/clienthelper/conector/Rx2ConnectableNodeTest.kt
+++ b/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/clienthelper/conector/Rx2ConnectableNodeTest.kt
@@ -8,9 +8,9 @@ import com.badoo.ribs.rx2.clienthelper.conector.helpers.Rx2ConnectableTestRib.Ou
 import com.badoo.ribs.rx2.clienthelper.conector.helpers.Rx2ConnectableTestRib.Output.Output2
 import com.badoo.ribs.test.BaseConnectableNodeTest
 import io.reactivex.observers.TestObserver
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 
 class Rx2ConnectableNodeTest : BaseConnectableNodeTest() {
@@ -25,12 +25,12 @@ class Rx2ConnectableNodeTest : BaseConnectableNodeTest() {
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         parent = Rx2ConnectableTestNode(plugins = listOf(changesAwarePlugin))
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         testObserver.dispose()
     }

--- a/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/clienthelper/conector/helpers/AnyConfiguration.kt
+++ b/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/clienthelper/conector/helpers/AnyConfiguration.kt
@@ -1,7 +1,7 @@
 package com.badoo.ribs.rx2.clienthelper.conector.helpers
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 object AnyConfiguration : Parcelable { override fun toString(): String = "AnyConfiguration" }

--- a/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/workflows/WorkflowTest.kt
+++ b/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/workflows/WorkflowTest.kt
@@ -19,11 +19,11 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
-import kotlinx.android.parcel.Parcelize
-import org.junit.After
+import kotlinx.parcelize.Parcelize
 import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class WorkflowTest {
     private lateinit var node: RxWorkflowNode<TestView>
@@ -36,7 +36,7 @@ class WorkflowTest {
     private lateinit var child3: TestNode
     private lateinit var childAncestry: AncestryInfo
 
-    @Before
+    @BeforeEach
     fun setUp() {
         parentView = mock()
         androidView = mock()
@@ -48,7 +48,7 @@ class WorkflowTest {
         addChildren()
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         RIBs.clearErrorHandler()
     }

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -25,8 +24,7 @@ sourceSets {
 }
 
 repositories {
-    jcenter()
-    maven { url "https://maven.google.com" }
+    google()
     maven { url "https://jitpack.io" }
     maven {
         url "https://plugins.gradle.org/m2/"

--- a/samples/android-integration/launching-activities/build.gradle
+++ b/samples/android-integration/launching-activities/build.gradle
@@ -24,11 +24,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
-
 dependencies {
     implementation deps.external.kotlinStdlib
     implementation deps.android.appCompat

--- a/samples/android-integration/launching-activities/src/main/java/com/badoo/ribs/samples/android_integration/launching_activities/rib/parent/LaunchingActivitiesParentRouter.kt
+++ b/samples/android-integration/launching-activities/src/main/java/com/badoo/ribs/samples/android_integration/launching_activities/rib/parent/LaunchingActivitiesParentRouter.kt
@@ -9,7 +9,7 @@ import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource.Companion.permanent
 import com.badoo.ribs.samples.android_integration.launching_activities.rib.parent.LaunchingActivitiesParentRouter.Configuration.Permanent
 import com.badoo.ribs.samples.android_integration.launching_activities.rib.parent.builder.LaunchingActivitiesChildBuilders
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class LaunchingActivitiesParentRouter(
     buildParams: BuildParams<*>,

--- a/samples/back-stack/build.gradle
+++ b/samples/back-stack/build.gradle
@@ -18,11 +18,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/back-stack/src/main/java/com/badoo/ribs/samples/back_stack/rib/parent/routing/ParentRouter.kt
+++ b/samples/back-stack/src/main/java/com/badoo/ribs/samples/back_stack/rib/parent/routing/ParentRouter.kt
@@ -14,7 +14,7 @@ import com.badoo.ribs.samples.back_stack.rib.parent.routing.ParentRouter.Configu
 import com.badoo.ribs.samples.back_stack.rib.parent.routing.ParentRouter.Configuration.Content.D
 import com.badoo.ribs.samples.back_stack.rib.parent.routing.ParentRouter.Configuration.Overlay.E
 import com.badoo.ribs.samples.back_stack.rib.parent.routing.ParentRouter.Configuration.Overlay.F
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class ParentRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/samples/build-time-dependencies/build.gradle
+++ b/samples/build-time-dependencies/build.gradle
@@ -21,10 +21,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/build-time-dependencies/src/main/java/com/badoo/ribs/samples/buildtime/rib/build_time_deps/BuildTimeDepsRouter.kt
+++ b/samples/build-time-dependencies/src/main/java/com/badoo/ribs/samples/buildtime/rib/build_time_deps/BuildTimeDepsRouter.kt
@@ -13,7 +13,7 @@ import com.badoo.ribs.samples.buildtime.rib.build_time_deps.BuildTimeDepsRouter.
 import com.badoo.ribs.samples.buildtime.rib.build_time_deps.BuildTimeDepsRouter.Configuration.ShowProfile
 import com.badoo.ribs.samples.buildtime.rib.profile.Profile
 import com.badoo.ribs.samples.buildtime.rib.profile.ProfileBuilder
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 internal class BuildTimeDepsRouter(
     buildParams: BuildParams<*>,

--- a/samples/communication-between-nodes-1/build.gradle
+++ b/samples/communication-between-nodes-1/build.gradle
@@ -17,11 +17,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/communication-between-nodes-1/src/main/java/com/badoo/ribs/samples/comms_nodes_1/rib/container/routing/ContainerRouter.kt
+++ b/samples/communication-between-nodes-1/src/main/java/com/badoo/ribs/samples/comms_nodes_1/rib/container/routing/ContainerRouter.kt
@@ -13,7 +13,7 @@ import com.badoo.ribs.samples.comms_nodes_1.rib.container.routing.ContainerRoute
 import com.badoo.ribs.samples.comms_nodes_1.rib.container.routing.ContainerRouter.Configuration.Content.Child2
 import com.badoo.ribs.samples.comms_nodes_1.rib.container.routing.ContainerRouter.Configuration.Content.Child3
 import com.badoo.ribs.samples.comms_nodes_1.rib.container.routing.ContainerRouter.Configuration.Permanent.Menu
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class ContainerRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/samples/communication-between-nodes-1/src/main/java/com/badoo/ribs/samples/comms_nodes_1/rib/menu/Menu.kt
+++ b/samples/communication-between-nodes-1/src/main/java/com/badoo/ribs/samples/comms_nodes_1/rib/menu/Menu.kt
@@ -5,7 +5,7 @@ import com.badoo.ribs.clienthelper.connector.Connectable
 import com.badoo.ribs.core.Rib
 import com.badoo.ribs.samples.comms_nodes_1.rib.menu.Menu.Input
 import com.badoo.ribs.samples.comms_nodes_1.rib.menu.Menu.Output
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 interface Menu : Rib, Connectable<Input, Output> {
 

--- a/samples/communication-between-nodes/src/main/java/com/badoo/ribs/samples/comms_nodes/rib/greeting_container/routing/GreetingContainerRouter.kt
+++ b/samples/communication-between-nodes/src/main/java/com/badoo/ribs/samples/comms_nodes/rib/greeting_container/routing/GreetingContainerRouter.kt
@@ -12,7 +12,7 @@ import com.badoo.ribs.samples.comms_nodes.rib.greeting_container.routing.Greetin
 import com.badoo.ribs.samples.comms_nodes.rib.greeting_container.routing.GreetingContainerRouter.Configuration.Greeting
 import com.badoo.ribs.samples.comms_nodes.rib.language_selector.Language
 import com.badoo.ribs.samples.comms_nodes.rib.language_selector.LanguageSelectorBuilder.Params
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 internal class GreetingContainerRouter(
     buildParams: BuildParams<Nothing?>,

--- a/samples/customisations-app/build.gradle
+++ b/samples/customisations-app/build.gradle
@@ -17,10 +17,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/dialogs/build.gradle
+++ b/samples/dialogs/build.gradle
@@ -17,10 +17,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/dialogs/src/main/java/com/badoo/ribs/samples/dialogs/rib/dialogs_example/DialogsRouter.kt
+++ b/samples/dialogs/src/main/java/com/badoo/ribs/samples/dialogs/rib/dialogs_example/DialogsRouter.kt
@@ -12,7 +12,7 @@ import com.badoo.ribs.samples.dialogs.dialogs.Dialogs
 import com.badoo.ribs.samples.dialogs.rib.dialogs_example.DialogsRouter.Configuration
 import com.badoo.ribs.samples.dialogs.rib.dialogs_example.DialogsRouter.Configuration.Content
 import com.badoo.ribs.samples.dialogs.rib.dialogs_example.DialogsRouter.Configuration.Overlay
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class DialogsRouter(
     buildParams: BuildParams<Nothing?>,

--- a/samples/hello-world/build.gradle
+++ b/samples/hello-world/build.gradle
@@ -17,10 +17,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/permissions/build.gradle
+++ b/samples/permissions/build.gradle
@@ -16,11 +16,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
-
 dependencies {
     implementation deps.external.kotlinStdlib
 

--- a/samples/permissions/src/main/java/com/badoo/ribs/samples/permissions/rib/parent/routing/PermissionsSampleParentRouter.kt
+++ b/samples/permissions/src/main/java/com/badoo/ribs/samples/permissions/rib/parent/routing/PermissionsSampleParentRouter.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.routing.source.RoutingSource.Companion.permanent
 import com.badoo.ribs.samples.permissions.rib.parent.routing.PermissionsSampleParentRouter.Configuration
 import com.badoo.ribs.samples.permissions.rib.parent.routing.PermissionsSampleParentRouter.Configuration.Permanent.Child1
 import com.badoo.ribs.samples.permissions.rib.parent.routing.PermissionsSampleParentRouter.Configuration.Permanent.Child2
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class PermissionsSampleParentRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/samples/plugins/build.gradle
+++ b/samples/plugins/build.gradle
@@ -20,10 +20,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/retained-instance-store/build.gradle
+++ b/samples/retained-instance-store/build.gradle
@@ -10,10 +10,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/retained-instance-store/src/main/java/com/badoo/ribs/samples/retained_instance_store/rib/retained_instance_example/RetainedInstanceExampleRouter.kt
+++ b/samples/retained-instance-store/src/main/java/com/badoo/ribs/samples/retained_instance_store/rib/retained_instance_example/RetainedInstanceExampleRouter.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource
 import com.badoo.ribs.samples.retained_instance_store.rib.counter.CounterBuilder
 import com.badoo.ribs.samples.retained_instance_store.rib.retained_instance_example.RetainedInstanceExampleRouter.Configuration.Content
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class RetainedInstanceExampleRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/samples/simple-routing-app/build.gradle
+++ b/samples/simple-routing-app/build.gradle
@@ -17,10 +17,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/simple-routing-rib/build.gradle
+++ b/samples/simple-routing-rib/build.gradle
@@ -19,10 +19,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     implementation deps.android.appCompat
     implementation deps.android.constraintLayout

--- a/samples/simple-routing-rib/src/main/java/com/badoo/ribs/samples/simplerouting/rib/simple_routing_child1/routing/SimpleRoutingChild1Router.kt
+++ b/samples/simple-routing-rib/src/main/java/com/badoo/ribs/samples/simplerouting/rib/simple_routing_child1/routing/SimpleRoutingChild1Router.kt
@@ -9,7 +9,7 @@ import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource.Companion.permanent
 import com.badoo.ribs.samples.simplerouting.rib.simple_routing_child1.routing.SimpleRoutingChild1Router.Configuration.Permanent.Child1
 import com.badoo.ribs.samples.simplerouting.rib.simple_routing_child1.routing.SimpleRoutingChild1Router.Configuration.Permanent.Child2
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class SimpleRoutingChild1Router internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/samples/simple-routing-rib/src/main/java/com/badoo/ribs/samples/simplerouting/rib/simple_routing_parent/routing/SimpleRoutingParentRouter.kt
+++ b/samples/simple-routing-rib/src/main/java/com/badoo/ribs/samples/simplerouting/rib/simple_routing_parent/routing/SimpleRoutingParentRouter.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.routing.source.RoutingSource.Companion.permanent
 import com.badoo.ribs.samples.simplerouting.rib.simple_routing_parent.routing.SimpleRoutingParentRouter.Configuration
 import com.badoo.ribs.samples.simplerouting.rib.simple_routing_parent.routing.SimpleRoutingParentRouter.Configuration.Permanent.Child1
 import com.badoo.ribs.samples.simplerouting.rib.simple_routing_parent.routing.SimpleRoutingParentRouter.Configuration.Permanent.Child2
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class SimpleRoutingParentRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/samples/transition-animations/build.gradle
+++ b/samples/transition-animations/build.gradle
@@ -17,10 +17,6 @@ android {
     }
 }
 
-androidExtensions {
-    experimental = true
-}
-
 dependencies {
     implementation deps.external.kotlinStdlib
     implementation deps.android.appCompat

--- a/samples/transition-animations/src/main/java/com/badoo/ribs/samples/transitionanimations/rib/parent/routing/ParentRouter.kt
+++ b/samples/transition-animations/src/main/java/com/badoo/ribs/samples/transitionanimations/rib/parent/routing/ParentRouter.kt
@@ -12,7 +12,7 @@ import com.badoo.ribs.samples.transitionanimations.rib.parent.routing.ParentRout
 import com.badoo.ribs.samples.transitionanimations.rib.parent.routing.ParentRouter.Configuration.Child1
 import com.badoo.ribs.samples.transitionanimations.rib.parent.routing.ParentRouter.Configuration.Child2
 import com.badoo.ribs.samples.transitionanimations.rib.parent.routing.ParentRouter.Configuration.Child3
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class ParentRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/sandbox-compose-placeholder/build.gradle
+++ b/sandbox-compose-placeholder/build.gradle
@@ -1,13 +1,11 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -21,11 +19,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-}
-
-androidExtensions {
-    experimental = true
-    features = ["parcelize"]
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/sandbox-compose/build.gradle
+++ b/sandbox-compose/build.gradle
@@ -25,7 +25,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion deps.versions.kotlinComposeCompilerVersion
+        kotlinCompilerVersion deps.versions.kotlin
         kotlinCompilerExtensionVersion deps.versions.compose
     }
 }

--- a/sandbox-compose/build.gradle
+++ b/sandbox-compose/build.gradle
@@ -1,13 +1,11 @@
 configureAndroidLibrary(project)
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -27,14 +25,9 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion deps.versions.kotlin
+        kotlinCompilerVersion deps.versions.kotlinComposeCompilerVersion
         kotlinCompilerExtensionVersion deps.versions.compose
     }
-}
-
-androidExtensions {
-    experimental = true
-    features = ["parcelize"]
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
@@ -66,6 +59,7 @@ dependencies {
     implementation deps.compose.ui
     implementation deps.compose.material
     implementation deps.compose.uiTooling
+    debugImplementation deps.compose.uiToolingPreview
     implementation deps.compose.foundation
 
     junitTestImplementation(project)

--- a/sandbox-compose/src/main/java/com/badoo/ribs/sandbox/rib/compose_parent/routing/ComposeParentRouter.kt
+++ b/sandbox-compose/src/main/java/com/badoo/ribs/sandbox/rib/compose_parent/routing/ComposeParentRouter.kt
@@ -11,7 +11,7 @@ import com.badoo.ribs.routing.transition.handler.TransitionHandler
 import com.badoo.ribs.sandbox.rib.compose_leaf.ComposeLeaf
 import com.badoo.ribs.sandbox.rib.compose_parent.routing.ComposeParentRouter.Configuration
 import com.badoo.ribs.sandbox.rib.compose_parent.routing.ComposeParentRouter.Configuration.Content
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class ComposeParentRouter internal constructor(
     buildParams: BuildParams<*>,

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -29,7 +29,7 @@ android {
         }
 
         composeOptions {
-            kotlinCompilerVersion deps.versions.kotlinComposeCompilerVersion
+            kotlinCompilerVersion deps.versions.kotlin
             kotlinCompilerExtensionVersion deps.versions.compose
         }
     }

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -3,12 +3,12 @@ configureAndroidApp(project)
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.badoo.ribs.sandbox"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -29,15 +29,10 @@ android {
         }
 
         composeOptions {
-            kotlinCompilerVersion deps.versions.kotlin
+            kotlinCompilerVersion deps.versions.kotlinComposeCompilerVersion
             kotlinCompilerExtensionVersion deps.versions.compose
         }
     }
-}
-
-androidExtensions {
-    experimental = true
-    features = ["parcelize"]
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
@@ -79,6 +74,7 @@ dependencies {
         implementation deps.compose.ui
         implementation deps.compose.material
         implementation deps.compose.uiTooling
+        debugImplementation deps.compose.uiToolingPreview
         implementation deps.compose.foundation
     } else {
         implementation project(":sandbox-compose-placeholder")

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/app/RecyclerViewTestActivity.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/app/RecyclerViewTestActivity.kt
@@ -32,7 +32,7 @@ import com.badoo.ribs.sandbox.rib.switcher.Switcher
 import com.badoo.ribs.sandbox.rib.switcher.SwitcherBuilder
 import com.badoo.ribs.sandbox.util.CoffeeMachine
 import com.badoo.ribs.sandbox.util.StupidCoffeeMachine
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /** The sample app's single activity */
 class RecyclerViewTestActivity : RibActivity() {

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/big/routing/BigRouter.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/big/routing/BigRouter.kt
@@ -9,7 +9,7 @@ import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource.Companion.permanent
 import com.badoo.ribs.sandbox.rib.big.routing.BigRouter.Configuration
 import com.badoo.ribs.sandbox.rib.big.routing.BigRouter.Configuration.Permanent
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class BigRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/routing/DialogExampleRouter.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/routing/DialogExampleRouter.kt
@@ -13,7 +13,7 @@ import com.badoo.ribs.sandbox.rib.dialog_example.dialog.Dialogs
 import com.badoo.ribs.sandbox.rib.dialog_example.routing.DialogExampleRouter.Configuration
 import com.badoo.ribs.sandbox.rib.dialog_example.routing.DialogExampleRouter.Configuration.Content
 import com.badoo.ribs.sandbox.rib.dialog_example.routing.DialogExampleRouter.Configuration.Overlay
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class DialogExampleRouter(
     buildParams: BuildParams<Nothing?>,

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/hello_world/routing/HelloWorldRouter.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/hello_world/routing/HelloWorldRouter.kt
@@ -9,7 +9,7 @@ import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.routing.source.RoutingSource.Companion.permanent
 import com.badoo.ribs.sandbox.rib.hello_world.routing.HelloWorldRouter.Configuration
 import com.badoo.ribs.sandbox.rib.hello_world.routing.HelloWorldRouter.Configuration.Permanent.Small
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class HelloWorldRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/menu/Menu.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/menu/Menu.kt
@@ -6,7 +6,7 @@ import com.badoo.ribs.core.Rib
 import com.badoo.ribs.core.customisation.RibCustomisation
 import com.badoo.ribs.sandbox.rib.menu.Menu.Input
 import com.badoo.ribs.sandbox.rib.menu.Menu.Output
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 interface Menu : Rib, Connectable<Input, Output> {
 

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/small/routing/SmallRouter.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/small/routing/SmallRouter.kt
@@ -11,7 +11,7 @@ import com.badoo.ribs.routing.source.RoutingSource
 import com.badoo.ribs.sandbox.rib.small.routing.SmallRouter.Configuration
 import com.badoo.ribs.sandbox.rib.small.routing.SmallRouter.Configuration.Content
 import com.badoo.ribs.sandbox.rib.small.routing.SmallRouter.Configuration.FullScreen
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class SmallRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/switcher/routing/SwitcherRouter.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/switcher/routing/SwitcherRouter.kt
@@ -16,7 +16,7 @@ import com.badoo.ribs.sandbox.rib.switcher.routing.SwitcherRouter.Configuration
 import com.badoo.ribs.sandbox.rib.switcher.routing.SwitcherRouter.Configuration.Content
 import com.badoo.ribs.sandbox.rib.switcher.routing.SwitcherRouter.Configuration.Overlay
 import com.badoo.ribs.sandbox.rib.switcher.routing.SwitcherRouter.Configuration.Permanent
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class SwitcherRouter internal constructor(
     buildParams: BuildParams<Nothing?>,

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,5 +48,6 @@ include ':sandbox'
 include ':templates:release-0.27'
 include ':templates:snapshot'
 include ':tooling:rib-intellij-plugin'
+include ':internal:junitextensions'
 
 includeBuild("plugins")

--- a/templates/common-template.gradle
+++ b/templates/common-template.gradle
@@ -1,12 +1,7 @@
 configureAndroidLibrary(project)
 
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
-
-androidExtensions {
-    experimental = true
-}
 
 dependencies {
     kapt deps.apt.daggerCompiler

--- a/templates/release-0.27/src/main/java/com/badoo/ribs/template/node/foo_bar/routing/FooBarRouter.kt
+++ b/templates/release-0.27/src/main/java/com/badoo/ribs/template/node/foo_bar/routing/FooBarRouter.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.routing.source.RoutingSource
 import com.badoo.ribs.routing.transition.handler.TransitionHandler
 import com.badoo.ribs.template.node.foo_bar.routing.FooBarRouter.Configuration
 import com.badoo.ribs.template.node.foo_bar.routing.FooBarRouter.Configuration.Content
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class FooBarRouter internal constructor(
     buildParams: BuildParams<*>,

--- a/templates/snapshot/src/main/java/com/badoo/ribs/template/node/foo_bar/routing/FooBarRouter.kt
+++ b/templates/snapshot/src/main/java/com/badoo/ribs/template/node/foo_bar/routing/FooBarRouter.kt
@@ -10,7 +10,7 @@ import com.badoo.ribs.routing.source.RoutingSource
 import com.badoo.ribs.routing.transition.handler.TransitionHandler
 import com.badoo.ribs.template.node.foo_bar.routing.FooBarRouter.Configuration
 import com.badoo.ribs.template.node.foo_bar.routing.FooBarRouter.Configuration.Content
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class FooBarRouter internal constructor(
     buildParams: BuildParams<*>,


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

- Update to Kotlin 1.5.10 (when **useCompose** is true) and update required dependencies
- Make AndroidX dependencies versions explicit in case of Compose
- Use AGP 4.2.2 instead of different AGP versions
- Set compileSdk and targetSdk to 30, update Robolectric
- Move to kotlin-parcelize instead of removed kotlin-android-extensions
- Remove jcenter() from repositories list
- Use JUnit5 automatic extension loading to fix unit tests errors due isMainThread() check
- Convert failed tests to JUnit5
- Update Coil library version

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
