### PR TITLE
Workflow should throw meaningful error on Node destruction

### DIFF
--- a/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/workflows/WorkflowTest.kt
+++ b/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/workflows/WorkflowTest.kt
@@ -18,7 +18,6 @@ import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import io.reactivex.Single
-import io.reactivex.observers.TestObserver
 import kotlinx.parcelize.Parcelize
 import org.junit.Assert
 import org.junit.jupiter.api.AfterEach
@@ -26,7 +25,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class WorkflowTest {
-    private lateinit var node: RxWorkflowNode<TestView>
+    private lateinit var node: TestRxWorkflowNode<TestView>
     private lateinit var view: TestView
     private lateinit var androidView: ViewGroup
     private lateinit var parentView: RibView
@@ -57,7 +56,7 @@ class WorkflowTest {
         buildParams: BuildParams<Nothing?> = testBuildParams(),
         viewFactory: ViewFactory<TestView> = this.viewFactory,
         plugins: List<Plugin> = emptyList()
-    ): RxWorkflowNode<TestView> = RxWorkflowNode(
+    ): TestRxWorkflowNode<TestView> = TestRxWorkflowNode(
         buildParams = buildParams,
         viewFactory = viewFactory,
         plugins = plugins
@@ -89,13 +88,11 @@ class WorkflowTest {
 
     @Test
     fun `executeWorkflow executes action on subscribe`() {
-        var actionInvoked = false
-        val action = { actionInvoked = true }
+        val action = InvokableStub()
         val workflow: Single<Node<*>> = node.executeWorkflowInternal(action)
-        val testObserver = TestObserver<Node<*>>()
-        workflow.subscribe(testObserver)
+        val testObserver = workflow.test()
 
-        Assert.assertEquals(true, actionInvoked)
+        action.assertInvoked()
         testObserver.assertValue(node)
         testObserver.assertComplete()
     }
@@ -104,26 +101,38 @@ class WorkflowTest {
     fun `executeWorkflow never executes action on lifecycle terminate before subscribe`() {
         node.onDestroy(isRecreating = false)
 
-        var actionInvoked = false
-        val action = { actionInvoked = true }
+        val action = InvokableStub()
         val workflow: Single<Node<*>> = node.executeWorkflowInternal(action)
-        val testObserver = TestObserver<Node<*>>()
-        workflow.subscribe(testObserver)
+        val testObserver = workflow.test()
 
-        Assert.assertEquals(false, actionInvoked)
-        testObserver.assertNever(node)
-        testObserver.assertNotComplete()
+        action.assertNotInvoked()
+        testObserver.assertNoValues()
+        testObserver.assertError(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `executeWorkflow does not interrupt further actions on lifecycle terminate`() {
+        val action = InvokableStub()
+        val workflow: Single<Any> =
+            node
+                .executeWorkflowInternal<Node<*>>(action)
+                .flatMap { Single.never<Any>() }
+        val testObserver = workflow.test()
+
+        node.onDestroy(isRecreating = false)
+
+        action.assertInvoked()
+        testObserver.assertNoValues()
+        testObserver.assertNotTerminated()
     }
 
     @Test
     fun `attachWorkflow executes action on subscribe`() {
-        var actionInvoked = false
-        val action = { actionInvoked = true }
+        val action = InvokableStub()
         val workflow: Single<TestNode> = node.attachWorkflowInternal(action)
-        val testObserver = TestObserver<TestNode>()
-        workflow.subscribe(testObserver)
+        val testObserver = workflow.test()
 
-        Assert.assertEquals(true, actionInvoked)
+        action.assertInvoked()
         testObserver.assertValue(child3)
         testObserver.assertComplete()
     }
@@ -132,27 +141,38 @@ class WorkflowTest {
     fun `attachWorkflow never executes action on lifecycle terminate before subscribe`() {
         node.onDestroy(isRecreating = false)
 
-        var actionInvoked = false
-        val action = { actionInvoked = true }
+        val action = InvokableStub()
         val workflow: Single<TestNode> = node.attachWorkflowInternal(action)
-        val testObserver = TestObserver<TestNode>()
-        workflow.subscribe(testObserver)
+        val testObserver = workflow.test()
 
-        Assert.assertEquals(false, actionInvoked)
-        testObserver.assertNever(child1)
-        testObserver.assertNever(child2)
-        testObserver.assertNever(child3)
-        testObserver.assertNotComplete()
+        action.assertNotInvoked()
+        testObserver.assertNoValues()
+        testObserver.assertError(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `attachWorkflow does not interrupt further actions on lifecycle terminate`() {
+        val action = InvokableStub()
+        val workflow: Single<Any> =
+            node
+                .attachWorkflowInternal<Node<*>>(action)
+                .flatMap { Single.never<Any>() }
+        val testObserver = workflow.test()
+
+        node.onDestroy(isRecreating = false)
+
+        action.assertInvoked()
+        testObserver.assertNoValues()
+        testObserver.assertNotTerminated()
     }
 
     @Test
     fun `waitForChildAttached emits expected child immediately if it's already attached`() {
-        val workflow: Single<TestNode2> = node.waitForChildAttachedInternal()
-        val testObserver = TestObserver<TestNode2>()
         val testChildNode = TestNode2(buildParams = testBuildParams(ancestryInfo = childAncestry))
 
         node.attachChildNode(testChildNode)
-        workflow.subscribe(testObserver)
+        val workflow: Single<TestNode2> = node.waitForChildAttachedInternal()
+        val testObserver = workflow.test()
 
         testObserver.assertValue(testChildNode)
         testObserver.assertComplete()
@@ -163,11 +183,40 @@ class WorkflowTest {
         node.onDestroy(isRecreating = false)
 
         val workflow: Single<TestNode2> = node.waitForChildAttachedInternal()
-        val testObserver = TestObserver<TestNode2>()
-        workflow.subscribe(testObserver)
+        val testObserver = workflow.test()
 
         testObserver.assertNoValues()
-        testObserver.assertNotComplete()
+        testObserver.assertError(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `waitForChildAttached does not interrupt further actions on lifecycle terminate`() {
+        val workflow: Single<Any> =
+            node
+                .waitForChildAttachedInternal<Node<*>>()
+                .flatMap { Single.never<Any>() }
+        val testObserver = workflow.test()
+
+        node.onDestroy(isRecreating = false)
+
+        testObserver.assertNoValues()
+        testObserver.assertNotTerminated()
+    }
+
+    private class InvokableStub : () -> Unit {
+        var isInvoked: Boolean = false
+
+        override fun invoke() {
+            isInvoked = true
+        }
+
+        fun assertInvoked() {
+            Assert.assertEquals("Expected to be invoked", true, isInvoked)
+        }
+
+        fun assertNotInvoked() {
+            Assert.assertEquals("Expected to be not invoked", false, isInvoked)
+        }
     }
 
     private class TestNode(
@@ -191,6 +240,23 @@ class WorkflowTest {
         viewFactory = viewFactory,
         plugins = plugins + listOf(router)
     )
+
+    private class TestRxWorkflowNode<V : RibView>(
+        buildParams: BuildParams<*>,
+        viewFactory: ViewFactory<V>?,
+        plugins: List<Plugin>,
+    ) : RxWorkflowNode<V>(buildParams, viewFactory, plugins) {
+        inline fun <reified T> waitForChildAttachedInternal(): Single<T> =
+            waitForChildAttached()
+
+        inline fun <reified T> executeWorkflowInternal(
+            crossinline action: () -> Unit
+        ): Single<T> = executeWorkflow(action)
+
+        inline fun <reified T> attachWorkflowInternal(
+            crossinline action: () -> Unit
+        ): Single<T> = attachWorkflow(action)
+    }
 
     private class TestView : AndroidRibView() {
         override val androidView: ViewGroup = mock()


### PR DESCRIPTION
Throws proper.

Closes https://github.com/badoo/RIBs/issues/350, see comments.