### PR TITLE
Set ViewTreeLifecycleOwner for RibView

### DIFF
--- a/libraries/rib-base-test-activity/src/androidTest/java/com/badoo/ribs/test/sample/SampleView.kt
+++ b/libraries/rib-base-test-activity/src/androidTest/java/com/badoo/ribs/test/sample/SampleView.kt
@@ -22,8 +22,8 @@ class SampleViewImpl(
     override val androidView: ViewGroup
 
     init {
-        androidView = FrameLayout(context.parent.context)
-        val child = TextView(context.parent.context)
+        androidView = FrameLayout(context.context)
+        val child = TextView(context.context)
         child.id = viewId
         child.text = TextView::class.qualifiedName
         androidView.addView(child)

--- a/libraries/rib-base/src/androidTest/java/com/badoo/ribs/test/util/ribs/child/builder/TestChildBuilder.kt
+++ b/libraries/rib-base/src/androidTest/java/com/badoo/ribs/test/util/ribs/child/builder/TestChildBuilder.kt
@@ -24,7 +24,7 @@ class TestChildBuilder : Builder<TestChildBuilder.Params, TestNode<TestChildView
             viewFactory = {
                 ViewFactory {
                     TestChildViewImpl(
-                        context = it.parent.context,
+                        context = it.context,
                         addEditText = buildParams.payload.addEditText
                     )
                 }

--- a/libraries/rib-base/src/androidTest/java/com/badoo/ribs/test/util/ribs/root/builder/TestRootBuilder.kt
+++ b/libraries/rib-base/src/androidTest/java/com/badoo/ribs/test/util/ribs/root/builder/TestRootBuilder.kt
@@ -23,7 +23,7 @@ class TestRootBuilder(
             buildParams = buildParams,
             viewFactory = {
                 ViewFactory {
-                    TestRootViewImpl(it.parent.context)
+                    TestRootViewImpl(it.context)
                 }
             },
             router = dependency.router,

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/core/customisation/RibCustomisationExtensions.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/core/customisation/RibCustomisationExtensions.kt
@@ -1,25 +1,22 @@
 package com.badoo.ribs.core.customisation
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.view.RibView
-import com.badoo.ribs.core.view.ViewFactory
 
 fun customisations(block: RibCustomisationDirectoryImpl.() -> Unit): RibCustomisationDirectoryImpl =
     RibCustomisationDirectoryImpl().apply(block)
 
-fun <T> ViewFactory.Context.inflate(@LayoutRes layoutResourceId: Int): T =
-    parent.inflate(layoutResourceId)
-
+@Deprecated(
+    message = "Use ViewFactory.Context.inflate to properly support Jetpack intergations",
+    level = DeprecationLevel.ERROR
+)
 fun <T> RibView.inflate(@LayoutRes layoutResourceId: Int): T =
-    androidView.inflate(layoutResourceId)
+    throw NotImplementedError()
 
+@Deprecated(
+    message = "Use ViewFactory.Context.inflate to properly support Jetpack intergations",
+    level = DeprecationLevel.ERROR,
+)
 fun <T> ViewGroup.inflate(@LayoutRes layoutResourceId: Int): T =
-    LayoutInflater
-        .from(context)
-        .inflate(
-            layoutResourceId,
-            this,
-            false
-        ) as T
+    throw NotImplementedError()

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/core/view/ViewFactory.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/core/view/ViewFactory.kt
@@ -1,10 +1,32 @@
 package com.badoo.ribs.core.view
 
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewTreeLifecycleOwner
 
 fun interface ViewFactory<View> : (ViewFactory.Context) -> View {
     class Context(
-        val parent: RibView,
+        internal val parent: RibView,
         val lifecycle: Lifecycle,
-    )
+    ) {
+        val context: android.content.Context get() = parent.context
+
+        fun <T : View> inflate(@LayoutRes layoutResourceId: Int): T {
+            val view = parent.androidView.inflate<T>(layoutResourceId)
+            ViewTreeLifecycleOwner.set(view) { lifecycle }
+            return view
+        }
+
+        private fun <T> ViewGroup.inflate(@LayoutRes layoutResourceId: Int): T =
+            LayoutInflater
+                .from(context)
+                .inflate(
+                    layoutResourceId,
+                    this,
+                    false,
+                ) as T
+    }
 }

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodePluginTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/NodePluginTest.kt
@@ -11,10 +11,10 @@ import com.badoo.ribs.core.plugin.Plugin
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.routing.Routing
-import org.mockito.kotlin.argThat
+import org.junit.Before
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.junit.Before
 
 open class NodePluginTest {
     protected lateinit var view: TestView
@@ -30,7 +30,7 @@ open class NodePluginTest {
         androidView = mock()
         view = mock { on { androidView }.thenReturn(androidView) }
         viewFactory =
-            mock { on { invoke(argThat(predicate = { parent == parentView })) } doReturn view }
+            mock { on { invoke(any()) } doReturn view }
     }
 
     protected inline fun <reified T : Plugin> testPlugins(nbPlugins: Int = 3): Pair<Node<TestView>, List<T>> =

--- a/libraries/rib-compose/src/main/java/com/badoo/ribs/compose/ComposeRibView.kt
+++ b/libraries/rib-compose/src/main/java/com/badoo/ribs/compose/ComposeRibView.kt
@@ -3,6 +3,7 @@ package com.badoo.ribs.compose
 import android.content.Context
 import android.view.ViewGroup
 import androidx.compose.runtime.MutableState
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.view.RibView
 
@@ -25,6 +26,7 @@ abstract class ComposeRibView(
 
     override val androidView: ViewGroup by lazy(LazyThreadSafetyMode.NONE) {
         androidx.compose.ui.platform.ComposeView(context).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent(composable)
         }
     }
@@ -49,7 +51,6 @@ abstract class ComposeRibView(
         }
         child.onAttachToView()
     }
-
 
     override fun detachChild(child: Node<*>, subtreeOf: Node<*>) {
         val target = getChildHostForSubtree(subtreeOf)

--- a/libraries/rib-debug-utils/src/main/java/com/badoo/ribs/core/plugin/utils/debug/AbstractDebugControls.kt
+++ b/libraries/rib-debug-utils/src/main/java/com/badoo/ribs/core/plugin/utils/debug/AbstractDebugControls.kt
@@ -1,11 +1,12 @@
 package com.badoo.ribs.core.plugin.utils.debug
 
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.annotation.LayoutRes
 import com.badoo.ribs.base.R
 import com.badoo.ribs.core.Rib
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.plugin.NodeAware
 import com.badoo.ribs.core.plugin.NodeAwareImpl
 import com.badoo.ribs.core.plugin.RibAware
@@ -64,4 +65,15 @@ abstract class AbstractDebugControls<T : Rib> internal constructor(
     open fun onDebugViewCreated(debugView: View) {}
 
     open fun onDebugViewDestroyed(debugView: View) {}
+
+    companion object {
+        fun <T : View> ViewGroup.inflate(@LayoutRes layoutResourceId: Int): T =
+            LayoutInflater
+                .from(context)
+                .inflate(
+                    layoutResourceId,
+                    this,
+                    false
+                ) as T
+    }
 }

--- a/libraries/rib-debug-utils/src/main/java/com/badoo/ribs/core/plugin/utils/debug/DebugControlsHost.kt
+++ b/libraries/rib-debug-utils/src/main/java/com/badoo/ribs/core/plugin/utils/debug/DebugControlsHost.kt
@@ -7,7 +7,6 @@ import android.widget.Toast
 import com.badoo.ribs.debugutils.R
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.Rib
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.debug.TreePrinter
 
 class DebugControlsHost(

--- a/libraries/rib-recyclerview/src/main/java/com/badoo/ribs/android/recyclerview/RecyclerViewHostView.kt
+++ b/libraries/rib-recyclerview/src/main/java/com/badoo/ribs/android/recyclerview/RecyclerViewHostView.kt
@@ -29,13 +29,13 @@ internal class RecyclerViewHostViewImpl private constructor(
             RecyclerViewHostViewImpl(
                 androidView = deps
                     .recyclerViewFactory()
-                    .invoke(it.parent.androidView.context)
+                    .invoke(it.context)
                     .apply {
                         adapter = deps.adapter()
                         layoutManager =
                             deps
                                 .layoutManagerFactory()
-                                .invoke(it.parent.androidView.context)
+                                .invoke(it.context)
                     }
             )
         }

--- a/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/workflows/WorkflowTest.kt
+++ b/libraries/rib-rx2/src/test/java/com/badoo/ribs/rx2/workflows/WorkflowTest.kt
@@ -14,9 +14,6 @@ import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.routing.Routing
 import com.badoo.ribs.routing.router.Router
 import com.badoo.ribs.util.RIBs
-import org.mockito.kotlin.argThat
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
 import kotlinx.parcelize.Parcelize
@@ -24,6 +21,9 @@ import org.junit.Assert
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 class WorkflowTest {
     private lateinit var node: RxWorkflowNode<TestView>
@@ -41,7 +41,7 @@ class WorkflowTest {
         parentView = mock()
         androidView = mock()
         view = mock { on { androidView }.thenReturn(androidView) }
-        viewFactory = mock { on { invoke(argThat { parent == parentView }) } doReturn view }
+        viewFactory = mock { on { invoke(any()) } doReturn view }
         node = createNode(viewFactory = viewFactory)
         childAncestry = AncestryInfo.Child(node, Routing(AnyConfiguration))
 

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/android/container/AndroidContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/android/container/AndroidContainerView.kt
@@ -26,7 +26,7 @@ class AndroidContainerViewImpl private constructor(
     class Factory : AndroidContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<AndroidContainerView> = ViewFactory {
             AndroidContainerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/android/picker/AndroidPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/android/picker/AndroidPickerView.kt
@@ -35,7 +35,7 @@ class AndroidPickerViewImpl private constructor(
     class Factory : AndroidPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<AndroidPickerView> = ViewFactory {
             AndroidPickerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/communication/container/CommunicationContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/communication/container/CommunicationContainerView.kt
@@ -26,7 +26,7 @@ class CommunicationContainerViewImpl private constructor(
     class Factory : CommunicationContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<CommunicationContainerView> = ViewFactory {
             CommunicationContainerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/communication/picker/CommunicationPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/communication/picker/CommunicationPickerView.kt
@@ -34,7 +34,7 @@ class CommunicationPickerViewImpl private constructor(
     class Factory : CommunicationPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<CommunicationPickerView> = ViewFactory {
             CommunicationPickerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/other/container/OtherContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/other/container/OtherContainerView.kt
@@ -26,7 +26,7 @@ class OtherContainerViewImpl private constructor(
     class Factory : OtherContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<OtherContainerView> = ViewFactory {
             OtherContainerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/other/picker/OtherPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/other/picker/OtherPickerView.kt
@@ -33,7 +33,7 @@ class OtherPickerViewImpl private constructor(
     class Factory : OtherPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<OtherPickerView> = ViewFactory {
             OtherPickerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/root/container/RootContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/root/container/RootContainerView.kt
@@ -27,7 +27,7 @@ class RootContainerViewImpl private constructor(
     class Factory : RootContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<RootContainerView> = ViewFactory {
             RootContainerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/root/picker/RootPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/root/picker/RootPickerView.kt
@@ -36,7 +36,7 @@ class RootPickerViewImpl private constructor(
     class Factory : RootPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<RootPickerView> = ViewFactory {
             RootPickerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/routing/routing_container/RoutingContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/routing/routing_container/RoutingContainerView.kt
@@ -26,7 +26,7 @@ class RoutingContainerViewImpl private constructor(
     class Factory : RoutingContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<RoutingContainerView> = ViewFactory {
             RoutingContainerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/routing/routing_picker/RoutingPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/routing/routing_picker/RoutingPickerView.kt
@@ -36,7 +36,7 @@ class RoutingPickerViewImpl private constructor(
     class Factory : RoutingPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<RoutingPickerView> = ViewFactory {
             RoutingPickerViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/samples/app/hello-world/src/main/java/com/badoo/ribs/samples/helloworld/hello_world/HelloWorldView.kt
+++ b/samples/app/hello-world/src/main/java/com/badoo/ribs/samples/helloworld/hello_world/HelloWorldView.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/app_bar/AppBarView.kt
+++ b/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/app_bar/AppBarView.kt
@@ -7,7 +7,6 @@ import coil.load
 import coil.transform.CircleCropTransformation
 import com.badoo.mvicore.ModelWatcher
 import com.badoo.mvicore.modelWatcher
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/feed_container/FeedContainerView.kt
+++ b/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/feed_container/FeedContainerView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.example.feed_container
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/photo_details/PhotoDetailsView.kt
+++ b/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/photo_details/PhotoDetailsView.kt
@@ -9,7 +9,6 @@ import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.Group
 import coil.load
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/photo_feed/view/PhotoFeedView.kt
+++ b/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/photo_feed/view/PhotoFeedView.kt
@@ -9,7 +9,6 @@ import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.Group
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/welcome/WelcomeView.kt
+++ b/samples/app/unsplash-client/src/main/java/com/badoo/ribs/example/welcome/WelcomeView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.example.welcome
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/android-integration/dialogs/src/main/java/com/badoo/ribs/samples/android/dialogs/rib/dialogs_example/DialogsExampleView.kt
+++ b/samples/elements/android-integration/dialogs/src/main/java/com/badoo/ribs/samples/android/dialogs/rib/dialogs_example/DialogsExampleView.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/android-integration/dialogs/src/main/java/com/badoo/ribs/samples/android/dialogs/rib/dummy/DummyView.kt
+++ b/samples/elements/android-integration/dialogs/src/main/java/com/badoo/ribs/samples/android/dialogs/rib/dummy/DummyView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.samples.android.dialogs.rib.dummy
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/android-integration/launching-activities/src/main/java/com/badoo/ribs/samples/android/launching_activities/rib/child_common/LaunchingActivitiesChildView.kt
+++ b/samples/elements/android-integration/launching-activities/src/main/java/com/badoo/ribs/samples/android/launching_activities/rib/child_common/LaunchingActivitiesChildView.kt
@@ -5,7 +5,6 @@ import android.widget.Button
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/android-integration/launching-activities/src/main/java/com/badoo/ribs/samples/android/launching_activities/rib/launching_activities_example/LaunchingActivitiesExampleView.kt
+++ b/samples/elements/android-integration/launching-activities/src/main/java/com/badoo/ribs/samples/android/launching_activities/rib/launching_activities_example/LaunchingActivitiesExampleView.kt
@@ -5,7 +5,6 @@ import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/android-integration/permissions/src/main/java/com/badoo/ribs/samples/android/permissions/rib/child1/PermissionsSampleChild1View.kt
+++ b/samples/elements/android-integration/permissions/src/main/java/com/badoo/ribs/samples/android/permissions/rib/child1/PermissionsSampleChild1View.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/android-integration/permissions/src/main/java/com/badoo/ribs/samples/android/permissions/rib/child2/PermissionsSampleChild2ViewImpl.kt
+++ b/samples/elements/android-integration/permissions/src/main/java/com/badoo/ribs/samples/android/permissions/rib/child2/PermissionsSampleChild2ViewImpl.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/android-integration/permissions/src/main/java/com/badoo/ribs/samples/android/permissions/rib/parent/PermissionsExampleView.kt
+++ b/samples/elements/android-integration/permissions/src/main/java/com/badoo/ribs/samples/android/permissions/rib/parent/PermissionsExampleView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.samples.android.permissions.rib.parent
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/communication/coordinate-multiple/src/main/java/com/badoo/ribs/samples/communication/coordinate_multiple_example/rib/greeting/GreetingView.kt
+++ b/samples/elements/communication/coordinate-multiple/src/main/java/com/badoo/ribs/samples/communication/coordinate_multiple_example/rib/greeting/GreetingView.kt
@@ -5,7 +5,6 @@ import android.widget.Button
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.android.text.Text
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/communication/coordinate-multiple/src/main/java/com/badoo/ribs/samples/communication/coordinate_multiple_example/rib/greeting_container/GreetingContainerView.kt
+++ b/samples/elements/communication/coordinate-multiple/src/main/java/com/badoo/ribs/samples/communication/coordinate_multiple_example/rib/greeting_container/GreetingContainerView.kt
@@ -20,7 +20,7 @@ class GreetingContainerViewImpl private constructor(
     class Factory : GreetingContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<GreetingContainerView> = ViewFactory { context ->
             GreetingContainerViewImpl(
-                FrameLayout(context.parent.context)
+                FrameLayout(context.context)
             )
         }
     }

--- a/samples/elements/communication/coordinate-multiple/src/main/java/com/badoo/ribs/samples/communication/coordinate_multiple_example/rib/language_selector/LanguageSelectorView.kt
+++ b/samples/elements/communication/coordinate-multiple/src/main/java/com/badoo/ribs/samples/communication/coordinate_multiple_example/rib/language_selector/LanguageSelectorView.kt
@@ -6,7 +6,6 @@ import android.widget.Button
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/child1/Child1View.kt
+++ b/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/child1/Child1View.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.communication.menu_example.rib.child1
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/child2/Child2View.kt
+++ b/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/child2/Child2View.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.communication.menu_example.rib.child2
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/child3/Child2View.kt
+++ b/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/child3/Child2View.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.communication.menu_example.rib.child3
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/menu/MenuView.kt
+++ b/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/menu/MenuView.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.core.content.ContextCompat
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/menu_example/MenuExampleView.kt
+++ b/samples/elements/communication/menu-example/src/main/java/com/badoo/ribs/samples/communication/menu_example/rib/menu_example/MenuExampleView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.samples.communication.menu_example.rib.menu_example
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/other/retained-instance-store/src/main/java/com/badoo/ribs/samples/retained_instance_store/rib/counter/CounterView.kt
+++ b/samples/elements/other/retained-instance-store/src/main/java/com/badoo/ribs/samples/retained_instance_store/rib/counter/CounterView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.samples.retained_instance_store.rib.counter
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/other/retained-instance-store/src/main/java/com/badoo/ribs/samples/retained_instance_store/rib/retained_instance_example/RetainedInstanceExampleView.kt
+++ b/samples/elements/other/retained-instance-store/src/main/java/com/badoo/ribs/samples/retained_instance_store/rib/retained_instance_example/RetainedInstanceExampleView.kt
@@ -6,7 +6,6 @@ import android.widget.FrameLayout
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/back_stack_example/BackStackExampleView.kt
+++ b/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/back_stack_example/BackStackExampleView.kt
@@ -7,7 +7,6 @@ import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_a/ChildAView.kt
+++ b/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_a/ChildAView.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.back_stack.rib.child_a
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_b/ChildBView.kt
+++ b/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_b/ChildBView.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.back_stack.rib.child_b
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_c/ChildCView.kt
+++ b/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_c/ChildCView.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.back_stack.rib.child_c
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_d/ChildDView.kt
+++ b/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_d/ChildDView.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.back_stack.rib.child_d
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_e/ChildEView.kt
+++ b/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_e/ChildEView.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.back_stack.rib.child_e
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_f/ChildFView.kt
+++ b/samples/elements/routing/back-stack/src/main/java/com/badoo/ribs/samples/routing/back_stack/rib/child_f/ChildFView.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.back_stack.rib.child_f
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/parameterised-routing/src/main/java/com/badoo/ribs/samples/routing/parameterised_routing/rib/parameterised_routing_example/ParameterisedRoutingExampleView.kt
+++ b/samples/elements/routing/parameterised-routing/src/main/java/com/badoo/ribs/samples/routing/parameterised_routing/rib/parameterised_routing_example/ParameterisedRoutingExampleView.kt
@@ -6,7 +6,6 @@ import android.widget.Button
 import android.widget.Spinner
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/parameterised-routing/src/main/java/com/badoo/ribs/samples/routing/parameterised_routing/rib/profile/ProfileView.kt
+++ b/samples/elements/routing/parameterised-routing/src/main/java/com/badoo/ribs/samples/routing/parameterised_routing/rib/profile/ProfileView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.samples.routing.parameterised_routing.rib.profile
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/child1/Child1View.kt
+++ b/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/child1/Child1View.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/child1_child1/Child1Child1View.kt
+++ b/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/child1_child1/Child1Child1View.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.simple_routing.rib.child1_child1
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/child1_child2/Child1Child2View.kt
+++ b/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/child1_child2/Child1Child2View.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.simple_routing.rib.child1_child2
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/child2/SimpleRoutingView.kt
+++ b/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/child2/SimpleRoutingView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.samples.routing.simple_routing.rib.child2
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/simple_routing_parent/SimpleRoutingParentView.kt
+++ b/samples/elements/routing/simple-routing-rib/src/main/java/com/badoo/ribs/samples/routing/simple_routing/rib/simple_routing_parent/SimpleRoutingParentView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.samples.routing.simple_routing.rib.simple_routing_parent
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/transition-animations/src/main/java/com/badoo/ribs/samples/routing/transition_animations/rib/child1/Child1View.kt
+++ b/samples/elements/routing/transition-animations/src/main/java/com/badoo/ribs/samples/routing/transition_animations/rib/child1/Child1View.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.transition_animations.rib.child1
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/transition-animations/src/main/java/com/badoo/ribs/samples/routing/transition_animations/rib/child2/Child2View.kt
+++ b/samples/elements/routing/transition-animations/src/main/java/com/badoo/ribs/samples/routing/transition_animations/rib/child2/Child2View.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.transition_animations.rib.child2
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/transition-animations/src/main/java/com/badoo/ribs/samples/routing/transition_animations/rib/child3/Child3View.kt
+++ b/samples/elements/routing/transition-animations/src/main/java/com/badoo/ribs/samples/routing/transition_animations/rib/child3/Child3View.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.samples.routing.transition_animations.rib.child3
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/samples/elements/routing/transition-animations/src/main/java/com/badoo/ribs/samples/routing/transition_animations/rib/transition_animations_example/TransitionAnimationsExampleView.kt
+++ b/samples/elements/routing/transition-animations/src/main/java/com/badoo/ribs/samples/routing/transition_animations/rib/transition_animations_example/TransitionAnimationsExampleView.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/big/BigView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/big/BigView.kt
@@ -6,7 +6,6 @@ import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.sandbox.R

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/blocker/BlockerView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/blocker/BlockerView.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.sandbox.R

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/compose_leaf/ComposeLeafView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/compose_leaf/ComposeLeafView.kt
@@ -50,7 +50,7 @@ class ComposeLeafViewImpl private constructor(
     class Factory : ComposeLeafView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<ComposeLeafView> = ViewFactory {
             ComposeLeafViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/compose_parent/ComposeParentView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/compose_parent/ComposeParentView.kt
@@ -54,7 +54,7 @@ class ComposeParentViewImpl private constructor(
     class Factory : ComposeParentView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<ComposeParentView> = ViewFactory {
             ComposeParentViewImpl(
-                it.parent.context
+                it.context
             )
         }
     }

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/dialog_example/DialogExampleView.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/foo_bar/FooBarView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/foo_bar/FooBarView.kt
@@ -6,7 +6,6 @@ import android.widget.Button
 import android.widget.TextView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.sandbox.R

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/hello_world/HelloDebugView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/hello_world/HelloDebugView.kt
@@ -3,7 +3,6 @@ package com.badoo.ribs.sandbox.rib.hello_world
 import android.view.View
 import android.widget.Button
 import android.widget.Toast
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.plugin.utils.debug.DebugControls
 import com.badoo.ribs.sandbox.R
 import io.reactivex.disposables.CompositeDisposable

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/hello_world/HelloWorldView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/hello_world/HelloWorldView.kt
@@ -6,7 +6,6 @@ import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.sandbox.R

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/lorem_ipsum/LoremIpsumView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/lorem_ipsum/LoremIpsumView.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.sandbox.R

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/menu/MenuView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/menu/MenuView.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.sandbox.R

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/portal_overlay_test/PortalOverlayTestView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/portal_overlay_test/PortalOverlayTestView.kt
@@ -4,7 +4,6 @@ import androidx.annotation.LayoutRes
 import android.view.ViewGroup
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.sandbox.R

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/small/SmallView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/small/SmallView.kt
@@ -6,7 +6,6 @@ import android.widget.Button
 import android.widget.TextView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.sandbox.R

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/switcher/SwitcherDebugView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/switcher/SwitcherDebugView.kt
@@ -2,7 +2,7 @@ package com.badoo.ribs.sandbox.rib.switcher
 
 import android.view.View
 import android.widget.Button
-import com.badoo.ribs.core.customisation.inflate
+
 import com.badoo.ribs.core.plugin.utils.debug.DebugControls
 import com.badoo.ribs.sandbox.R
 import io.reactivex.disposables.CompositeDisposable

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/switcher/SwitcherView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/switcher/SwitcherView.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.Node
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
@@ -54,7 +53,7 @@ class SwitcherViewImpl private constructor(
         override fun invoke(deps: SwitcherView.Dependency): ViewFactory<SwitcherView> =
             ViewFactory {
                 SwitcherViewImpl(
-                    it.parent.inflate(layoutRes),
+                    it.inflate(layoutRes),
                     deps.coffeeMachine()
                 )
             }

--- a/templates/release-0.27/src/main/java/com/badoo/ribs/template/leaf/foo_bar/FooBarView.kt
+++ b/templates/release-0.27/src/main/java/com/badoo/ribs/template/leaf/foo_bar/FooBarView.kt
@@ -2,11 +2,11 @@ package com.badoo.ribs.template.leaf.foo_bar
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.view.RibView
-import com.badoo.ribs.core.view.ViewFactoryBuilder
 import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
+import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
+import com.badoo.ribs.core.view.ViewFactoryBuilder
 import com.badoo.ribs.template.R
 import com.badoo.ribs.template.leaf.foo_bar.FooBarView.Event
 import com.badoo.ribs.template.leaf.foo_bar.FooBarView.ViewModel

--- a/templates/release-0.27/src/main/java/com/badoo/ribs/template/node/foo_bar/FooBarView.kt
+++ b/templates/release-0.27/src/main/java/com/badoo/ribs/template/node/foo_bar/FooBarView.kt
@@ -2,11 +2,11 @@ package com.badoo.ribs.template.node.foo_bar
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.view.RibView
-import com.badoo.ribs.core.view.ViewFactoryBuilder
 import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
+import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
+import com.badoo.ribs.core.view.ViewFactoryBuilder
 import com.badoo.ribs.template.R
 import com.badoo.ribs.template.node.foo_bar.FooBarView.Event
 import com.badoo.ribs.template.node.foo_bar.FooBarView.ViewModel

--- a/templates/snapshot/src/main/java/com/badoo/ribs/template/leaf/foo_bar/FooBarView.kt
+++ b/templates/snapshot/src/main/java/com/badoo/ribs/template/leaf/foo_bar/FooBarView.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.template.R

--- a/templates/snapshot/src/main/java/com/badoo/ribs/template/leaf_view_only/foo_bar/FooBarView.kt
+++ b/templates/snapshot/src/main/java/com/badoo/ribs/template/leaf_view_only/foo_bar/FooBarView.kt
@@ -2,7 +2,6 @@ package com.badoo.ribs.template.leaf_view_only.foo_bar
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory

--- a/templates/snapshot/src/main/java/com/badoo/ribs/template/node/foo_bar/FooBarView.kt
+++ b/templates/snapshot/src/main/java/com/badoo/ribs/template/node/foo_bar/FooBarView.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
-import com.badoo.ribs.core.customisation.inflate
 import com.badoo.ribs.core.view.AndroidRibView
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.template.R


### PR DESCRIPTION
So view components that relies on `ViewTreeLifecycleOwner` can easily use the correct one instead of Activity or Fragment one.

Also removed / made private other `inflate` methods.