### PR TITLE
Documentation update (RibsViewRule)

### DIFF
--- a/documentation/testing/unit-tests.md
+++ b/documentation/testing/unit-tests.md
@@ -169,7 +169,7 @@ class SomeViewImplTest {
 
     @get:Rule
     val rule = RibsViewRule { factoryContext ->
-        SomeScreenViewImpl.Factory().invoke(/* view factory context */ factoryContext)
+        SomeScreenViewImpl.Factory().invoke(/* dependency */ null).invoke(/* view factory context */ factoryContext)
     }
 
     @Test

--- a/documentation/testing/unit-tests.md
+++ b/documentation/testing/unit-tests.md
@@ -162,14 +162,14 @@ class SomeScreenInteractorTest {
 We can also unit test `View` implementation.
 In this test we should move `View` to some particular state and verify it by using `Espresso`.
 After that we can invoke some actions on `View` and verify that view sends events or invokes callbacks as expected.
-It can be easily done with the help of `RibViewTestRule`.
+It can be easily done with the help of `RibsViewRule`.
 
 ```kotlin
 class SomeViewImplTest {
 
     @get:Rule
-    val rule = RibViewTestRule { factoryContext ->
-        SomeScreenViewImpl.Factory().invoke(/* dependency */ null).invoke(/* view factory context */ factoryContext)
+    val rule = RibsViewRule { factoryContext ->
+        SomeScreenViewImpl.Factory().invoke(/* view factory context */ factoryContext)
     }
 
     @Test


### PR DESCRIPTION
RibViewTestRule isn’t part of rib-base-test nor rib-base-test-activity test helpers. It’s a helper class contained in InstrumentationTestUtils module from bumble source code. RibsViewRule can be used instead.

<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
