### PR TITLE
Make ComposeRibView.kt stable which is used as a receiver for some composable function

### DIFF
--- a/libraries/rib-compose/src/main/java/com/badoo/ribs/compose/ComposeRibView.kt
+++ b/libraries/rib-compose/src/main/java/com/badoo/ribs/compose/ComposeRibView.kt
@@ -3,6 +3,7 @@ package com.badoo.ribs.compose
 import android.content.Context
 import android.view.ViewGroup
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
 import com.badoo.ribs.core.Node
 import com.badoo.ribs.core.view.RibView
 
@@ -14,6 +15,7 @@ import com.badoo.ribs.core.view.RibView
  * @param childHostFactory Factory to provide ComposeChildHost, required to attach compose content
  * to a ViewGroup. Use a custom one if you need to customize the ViewGroup.
  */
+@Stable
 abstract class ComposeRibView(
     override val context: Context,
     private val childHostFactory: (MutableState<ComposeView?>, context: Context) -> ComposeChildHost = { state, context ->


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

If you access in your composable function properties or classes defined in your `View` class which extends `ComposeRibView` then this class will be added to your composable function as a parameter. Right now extensions of `ComposeRibView` are unstable not allowing to skip execution 

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

https://github.com/badoo/RIBs/issues/372

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
