### PR TITLE
Provide ViewTreeLifecycleOwner and ViewTreeSavedStateRegistryOwner

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,11 +30,12 @@ def versions = [
         androidxFragmentVersion        : '1.3.6', // https://developer.android.com/jetpack/androidx/releases/fragment
         androidxActivityVersion        : '1.3.1', // https://developer.android.com/jetpack/androidx/releases/activity
         androidxGridLayoutVersion      : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/gridlayout
-        androidxLifecycleVersion       : '2.3.1', // https://developer.android.com/jetpack/androidx/releases/lifecycle
+        androidxLifecycleVersion       : '2.4.1', // https://developer.android.com/jetpack/androidx/releases/lifecycle
         androidxLoaderVersion          : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/loader
         androidxPaletteVersion         : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/palette
         androidxPercentLayoutVersion   : '1.0.0', // https://developer.android.com/jetpack/androidx/releases/percentlayout
         androidxRecyclerViewVersion    : '1.1.0', // https://developer.android.com/jetpack/androidx/releases/recyclerview
+        androidxSavedStateVersion      : '1.2.0', // https://developer.android.com/jetpack/androidx/releases/savedstate
         androidxTestVersion            : '1.4.0', // https://developer.android.com/jetpack/androidx/releases/test
         androidxTestUiAutoVersion      : '2.2.0',
         retrofitVersion                : '2.9.0',
@@ -86,7 +87,8 @@ def android = [
         activity        : "androidx.activity:activity-ktx:${versions.androidxActivityVersion}",
         fragment        : "androidx.fragment:fragment-ktx:${versions.androidxFragmentVersion}",
         browser         : "androidx.browser:browser:${versions.androidxBrowserVersion}",
-        archCoreTesting : "androidx.arch.core:core-testing:${versions.androidxArchCoreVersion}"
+        archCoreTesting : "androidx.arch.core:core-testing:${versions.androidxArchCoreVersion}",
+        savedState      : "androidx.savedstate:savedstate:${versions.androidxSavedStateVersion}",
 ]
 
 def compose = [

--- a/libraries/rib-base/build.gradle
+++ b/libraries/rib-base/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api deps.external.appyxCustomisations
     implementation deps.android.activity
     implementation deps.android.fragment
+    implementation deps.android.savedState
     compileOnly deps.android.annotations
 
     testImplementation deps.external.mviCore

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/core/lifecycle/LifecycleManager.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/core/lifecycle/LifecycleManager.kt
@@ -98,8 +98,15 @@ internal class LifecycleManager(
         ribLifecycle.onDestroy()
     }
 
+    fun initializeViewLifecycle(): Lifecycle {
+        return CappedLifecycle(externalLifecycle)
+            .run {
+                viewLifecycle = this
+                lifecycle
+            }
+    }
+
     fun onViewCreated() {
-        viewLifecycle = CappedLifecycle(externalLifecycle)
         viewLifecycle!!.onCreate()
     }
 

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/core/view/AndroidRibView2.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/core/view/AndroidRibView2.kt
@@ -1,0 +1,43 @@
+package com.badoo.ribs.core.view
+
+import android.os.Bundle
+import android.view.ViewGroup
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+
+@Suppress("LeakingThis", "DEPRECATION") // owners approach always leaks "this"
+abstract class AndroidRibView2(
+    final override val androidView: ViewGroup,
+    private val lifecycle: Lifecycle,
+) : AndroidRibView(), LifecycleOwner, SavedStateRegistryOwner {
+
+    private val savedStateRegistryController = SavedStateRegistryController.create(this)
+
+    override val savedStateRegistry: SavedStateRegistry
+        get() = savedStateRegistryController.savedStateRegistry
+
+    init {
+        ViewTreeLifecycleOwner.set(androidView, this)
+        androidView.setViewTreeSavedStateRegistryOwner(this)
+        savedStateRegistryController.performAttach()
+    }
+
+    final override fun getLifecycle(): Lifecycle =
+        lifecycle
+
+    override fun saveInstanceState(bundle: Bundle) {
+        super.saveInstanceState(bundle)
+        savedStateRegistryController.performSave(bundle)
+    }
+
+    override fun restoreInstanceState(bundle: Bundle?) {
+        super.restoreInstanceState(bundle)
+        savedStateRegistryController.performRestore(bundle)
+    }
+
+}

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/core/view/RibView.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/core/view/RibView.kt
@@ -1,6 +1,7 @@
 package com.badoo.ribs.core.view
 
 import android.content.Context
+import android.os.Bundle
 import android.view.ViewGroup
 import com.badoo.ribs.core.Node
 
@@ -41,5 +42,14 @@ interface RibView {
      * Detaches a child from this view. Acts as the opposite of [attachChild].
      */
     fun detachChild(child: Node<*>, subtreeOf: Node<*>)
+
+    fun saveInstanceState(bundle: Bundle) {
+        // no-op
+    }
+
+    fun restoreInstanceState(bundle: Bundle?) {
+        // no-op
+    }
+
 }
 

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/android/container/AndroidContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/android/container/AndroidContainerView.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.compose.ComposeView
 import com.badoo.ribs.core.Node
@@ -19,14 +20,16 @@ interface AndroidContainerView : RibView {
 
 
 class AndroidContainerViewImpl private constructor(
-    context: Context
-) : ComposeRibView(context),
+    context: Context,
+    lifecycle: Lifecycle,
+) : ComposeRibView(context, lifecycle),
     AndroidContainerView {
 
     class Factory : AndroidContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<AndroidContainerView> = ViewFactory {
             AndroidContainerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/android/picker/AndroidPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/android/picker/AndroidPickerView.kt
@@ -3,6 +3,7 @@ package com.badoo.ribs.samples.gallery.rib.android.picker
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
@@ -27,15 +28,17 @@ interface AndroidPickerView : RibView,
 
 class AndroidPickerViewImpl private constructor(
     context: Context,
+    lifecycle: Lifecycle,
     private val events: PublishRelay<Event> = PublishRelay.create()
-) : ComposeRibView(context),
+) : ComposeRibView(context, lifecycle),
     AndroidPickerView,
     ObservableSource<Event> by events {
 
     class Factory : AndroidPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<AndroidPickerView> = ViewFactory {
             AndroidPickerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/communication/container/CommunicationContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/communication/container/CommunicationContainerView.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.compose.ComposeView
 import com.badoo.ribs.core.Node
@@ -19,14 +20,16 @@ interface CommunicationContainerView : RibView {
 
 
 class CommunicationContainerViewImpl private constructor(
-    context: Context
-) : ComposeRibView(context),
+    context: Context,
+    lifecycle: Lifecycle,
+) : ComposeRibView(context, lifecycle),
     CommunicationContainerView {
 
     class Factory : CommunicationContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<CommunicationContainerView> = ViewFactory {
             CommunicationContainerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/communication/picker/CommunicationPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/communication/picker/CommunicationPickerView.kt
@@ -3,6 +3,7 @@ package com.badoo.ribs.samples.gallery.rib.communication.picker
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
@@ -26,15 +27,17 @@ interface CommunicationPickerView : RibView,
 
 class CommunicationPickerViewImpl private constructor(
     context: Context,
+    lifecycle: Lifecycle,
     private val events: PublishRelay<Event> = PublishRelay.create()
-) : ComposeRibView(context),
+) : ComposeRibView(context, lifecycle),
     CommunicationPickerView,
     ObservableSource<Event> by events {
 
     class Factory : CommunicationPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<CommunicationPickerView> = ViewFactory {
             CommunicationPickerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/other/container/OtherContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/other/container/OtherContainerView.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.compose.ComposeView
 import com.badoo.ribs.core.Node
@@ -19,14 +20,16 @@ interface OtherContainerView : RibView {
 
 
 class OtherContainerViewImpl private constructor(
-    context: Context
-) : ComposeRibView(context),
+    context: Context,
+    lifecycle: Lifecycle,
+) : ComposeRibView(context, lifecycle),
     OtherContainerView {
 
     class Factory : OtherContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<OtherContainerView> = ViewFactory {
             OtherContainerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/other/picker/OtherPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/other/picker/OtherPickerView.kt
@@ -3,6 +3,7 @@ package com.badoo.ribs.samples.gallery.rib.other.picker
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
@@ -25,15 +26,17 @@ interface OtherPickerView : RibView,
 
 class OtherPickerViewImpl private constructor(
     context: Context,
+    lifecycle: Lifecycle,
     private val events: PublishRelay<Event> = PublishRelay.create()
-) : ComposeRibView(context),
+) : ComposeRibView(context, lifecycle),
     OtherPickerView,
     ObservableSource<Event> by events {
 
     class Factory : OtherPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<OtherPickerView> = ViewFactory {
             OtherPickerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/root/container/RootContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/root/container/RootContainerView.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.compose.ComposeView
 import com.badoo.ribs.core.Node
@@ -20,14 +21,16 @@ interface RootContainerView : RibView {
 
 
 class RootContainerViewImpl private constructor(
-    context: Context
-) : ComposeRibView(context),
+    context: Context,
+    lifecycle: Lifecycle,
+) : ComposeRibView(context, lifecycle),
     RootContainerView {
 
     class Factory : RootContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<RootContainerView> = ViewFactory {
             RootContainerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/root/picker/RootPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/root/picker/RootPickerView.kt
@@ -3,6 +3,7 @@ package com.badoo.ribs.samples.gallery.rib.root.picker
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
@@ -28,15 +29,17 @@ interface RootPickerView : RibView,
 
 class RootPickerViewImpl private constructor(
     context: Context,
+    lifecycle: Lifecycle,
     private val events: PublishRelay<Event> = PublishRelay.create()
-) : ComposeRibView(context),
+) : ComposeRibView(context, lifecycle),
     RootPickerView,
     ObservableSource<Event> by events {
 
     class Factory : RootPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<RootPickerView> = ViewFactory {
             RootPickerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/routing/routing_container/RoutingContainerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/routing/routing_container/RoutingContainerView.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.compose.ComposeView
 import com.badoo.ribs.core.Node
@@ -19,14 +20,16 @@ interface RoutingContainerView : RibView {
 
 
 class RoutingContainerViewImpl private constructor(
-    context: Context
-) : ComposeRibView(context),
+    context: Context,
+    lifecycle: Lifecycle,
+) : ComposeRibView(context, lifecycle),
     RoutingContainerView {
 
     class Factory : RoutingContainerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<RoutingContainerView> = ViewFactory {
             RoutingContainerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/routing/routing_picker/RoutingPickerView.kt
+++ b/samples/app/gallery/src/main/java/com/badoo/ribs/samples/gallery/rib/routing/routing_picker/RoutingPickerView.kt
@@ -3,6 +3,7 @@ package com.badoo.ribs.samples.gallery.rib.routing.routing_picker
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
@@ -28,15 +29,17 @@ interface RoutingPickerView : RibView,
 
 class RoutingPickerViewImpl private constructor(
     context: Context,
+    lifecycle: Lifecycle,
     private val events: PublishRelay<Event> = PublishRelay.create()
-) : ComposeRibView(context),
+) : ComposeRibView(context, lifecycle),
     RoutingPickerView,
     ObservableSource<Event> by events {
 
     class Factory : RoutingPickerView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<RoutingPickerView> = ViewFactory {
             RoutingPickerViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }

--- a/samples/elements/android-integration/permissions/build.gradle
+++ b/samples/elements/android-integration/permissions/build.gradle
@@ -27,11 +27,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
 
     debugImplementation project(":libraries:rib-base-test-activity")
-    androidTestImplementation project(":libraries:rib-base-test")
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
 }
 
 repositories {

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/compose_leaf/ComposeLeafView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/compose_leaf/ComposeLeafView.kt
@@ -5,16 +5,21 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactory
@@ -41,8 +46,9 @@ interface ComposeLeafView : RibView,
 
 class ComposeLeafViewImpl private constructor(
     context: Context,
+    lifecycle: Lifecycle,
     private val events: PublishRelay<Event> = PublishRelay.create()
-) : ComposeRibView(context),
+) : ComposeRibView(context, lifecycle),
     ComposeLeafView,
     ObservableSource<Event> by events,
     Consumer<ViewModel> {
@@ -50,7 +56,8 @@ class ComposeLeafViewImpl private constructor(
     class Factory : ComposeLeafView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<ComposeLeafView> = ViewFactory {
             ComposeLeafViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }
@@ -96,6 +103,21 @@ private fun View(viewModel: ViewModel) {
                 fontWeight = FontWeight.Bold,
                 text = viewModel.i.toString()
             )
+            LocalState()
+        }
+    }
+}
+
+@Composable
+private fun LocalState(modifier: Modifier = Modifier) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        var counter by rememberSaveable { mutableStateOf(0) }
+        Text(text = "LocalState: $counter")
+        Button(onClick = { counter++ }) {
+            Text(text = "Add")
         }
     }
 }

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/compose_parent/ComposeParentView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/compose_parent/ComposeParentView.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.compose.ComposeRibView
 import com.badoo.ribs.compose.ComposeView
 import com.badoo.ribs.core.Node
@@ -45,8 +46,9 @@ interface ComposeParentView : RibView,
 
 class ComposeParentViewImpl private constructor(
     context: Context,
+    lifecycle: Lifecycle,
     private val events: PublishRelay<Event> = PublishRelay.create()
-) : ComposeRibView(context),
+) : ComposeRibView(context, lifecycle),
     ComposeParentView,
     ObservableSource<Event> by events,
     Consumer<ViewModel> {
@@ -54,7 +56,8 @@ class ComposeParentViewImpl private constructor(
     class Factory : ComposeParentView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<ComposeParentView> = ViewFactory {
             ComposeParentViewImpl(
-                it.parent.context
+                it.parent.context,
+                it.lifecycle,
             )
         }
     }


### PR DESCRIPTION
- Provide `SavedStateRegistry` and `LifecycleOwner` per RIB view so Compose or any other views can use it.
- Introduce `AndroidRibView2` to keep compatibility with old code.


https://user-images.githubusercontent.com/9081555/192304144-d28d5d1a-43fe-46f5-a533-22e9bc76e1fe.mp4