### PR TITLE
Restore view state in RibsViewActivity.kt

### DIFF
--- a/libraries/rib-base-test-activity/src/main/java/com/badoo/ribs/test/view/RibsViewActivity.kt
+++ b/libraries/rib-base-test-activity/src/main/java/com/badoo/ribs/test/view/RibsViewActivity.kt
@@ -19,6 +19,7 @@ class RibsViewActivity : AppCompatActivity() {
         setContentView(R.layout.rib_test)
         val rootViewHost = AndroidRibViewHost(findViewById(R.id.rib_test_root))
         view = requireNotNull(VIEW_FACTORY).invoke(ViewFactory.Context(rootViewHost, lifecycle))
+        view.restoreInstanceState(null)
         setContentView(view.androidView)
     }
 

--- a/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/menu/MenuView.kt
+++ b/sandbox/src/main/java/com/badoo/ribs/sandbox/rib/menu/MenuView.kt
@@ -4,10 +4,11 @@ import androidx.annotation.LayoutRes
 import androidx.core.content.ContextCompat
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.lifecycle.Lifecycle
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.core.view.ViewFactoryBuilder
 import com.badoo.ribs.core.customisation.inflate
-import com.badoo.ribs.core.view.AndroidRibView
+import com.badoo.ribs.core.view.AndroidRibView2
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.sandbox.R
 import com.badoo.ribs.sandbox.rib.menu.Menu.MenuItem
@@ -32,9 +33,10 @@ interface MenuView : RibView, ObservableSource<Event>, Consumer<ViewModel> {
 
 
 class MenuViewImpl private constructor(
-    override val androidView: ViewGroup,
+    androidView: ViewGroup,
+    lifecycle: Lifecycle,
     private val events: PublishRelay<Event> = PublishRelay.create()
-) : AndroidRibView(),
+) : AndroidRibView2(androidView, lifecycle),
     MenuView,
     ObservableSource<Event> by events {
 
@@ -43,7 +45,8 @@ class MenuViewImpl private constructor(
     ) : MenuView.Factory {
         override fun invoke(deps: Nothing?): ViewFactory<MenuView> = ViewFactory {
             MenuViewImpl(
-                it.inflate(layoutRes)
+                it.inflate(layoutRes),
+                it.lifecycle
             )
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

`AndroidRibView2` uses `savedStateRegistry`. In RIBs view test `savedStateRegistry` state must be restored to avoid crash:

```
java.lang.IllegalStateException: You can consumeRestoredStateForKey only after super.onCreate of corresponding component
at androidx.savedstate.SavedStateRegistry.consumeRestoredStateForKey(SavedStateRegistry.kt:72)
at androidx.savedstate.Recreator.onStateChanged(Recreator.kt:34)
at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:354)
at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.java:265)
at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.java:307)
at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.java:148)
at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.java:134)
at androidx.lifecycle.ReportFragment.dispatch(ReportFragment.java:68)
at androidx.lifecycle.ReportFragment$LifecycleCallbacks.onActivityPostCreated(ReportFragment.java:178)
at android.app.Activity.dispatchActivityPostCreated(Activity.java:1345)
at android.app.Activity.performCreate(Activity.java:8064)
at android.app.Activity.performCreate(Activity.java:8034)
at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1341)
at androidx.test.runner.MonitoringInstrumentation.callActivityOnCreate(MonitoringInstrumentation.java:730)
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3666)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3842)
at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2252)
at android.os.Handler.dispatchMessage(Handler.java:106)
at android.os.Looper.loopOnce(Looper.java:201)
at android.os.Looper.loop(Looper.java:288)
at android.app.ActivityThread.main(ActivityThread.java:7842)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
