### PR TITLE
Raise fatal error if node called outside main thread

### DIFF
--- a/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/childaware/ChildAwareImplTest.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/clienthelper/childaware/ChildAwareImplTest.kt
@@ -12,6 +12,7 @@ import com.badoo.ribs.core.modality.BuildContext
 import com.badoo.ribs.core.modality.BuildParams
 import com.badoo.ribs.core.view.RibView
 import com.badoo.ribs.routing.Routing
+import com.badoo.ribs.store.RetainedInstanceStore
 import kotlinx.parcelize.Parcelize
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -25,6 +26,8 @@ class ChildAwareImplTest {
         Node<RibView>(
             buildParams = BuildParams(payload = null, buildContext = buildContext),
             viewFactory = null,
+            retainedInstanceStore = RetainedInstanceStore,
+            isOnMainThreadFunc = { true },
             plugins = listOf(registry),
         )
     }.apply {
@@ -269,6 +272,8 @@ class ChildAwareImplTest {
     ) : Node<RibView>(
         buildParams = BuildParams(payload = null, buildContext = buildContext),
         viewFactory = null,
+        retainedInstanceStore = RetainedInstanceStore,
+        isOnMainThreadFunc = { true },
     ), Child1 {
         override fun toString(): String = "${this::class.simpleName}@${hashCode()}"
     }
@@ -279,6 +284,8 @@ class ChildAwareImplTest {
     ) : Node<RibView>(
         buildParams = BuildParams(payload = null, buildContext = buildContext),
         viewFactory = null,
+        retainedInstanceStore = RetainedInstanceStore,
+        isOnMainThreadFunc = { true },
     ), Child2 {
         override fun toString(): String = "${this::class.simpleName}@${hashCode()}"
     }
@@ -289,6 +296,8 @@ class ChildAwareImplTest {
     ) : Node<RibView>(
         buildParams = BuildParams(payload = null, buildContext = buildContext),
         viewFactory = null,
+        retainedInstanceStore = RetainedInstanceStore,
+        isOnMainThreadFunc = { true },
     ), Child3 {
         override fun toString(): String = "${this::class.simpleName}@${hashCode()}"
     }

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestNode.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/TestNode.kt
@@ -5,6 +5,7 @@ import com.badoo.ribs.core.modality.BuildParams
 import com.badoo.ribs.core.plugin.Plugin
 import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.routing.router.Router
+import com.badoo.ribs.store.RetainedInstanceStore
 import org.mockito.kotlin.mock
 
 open class TestNode(
@@ -15,6 +16,8 @@ open class TestNode(
 ) : Node<TestView>(
     buildParams = buildParams,
     viewFactory = viewFactory,
+    retainedInstanceStore = RetainedInstanceStore,
+    isOnMainThreadFunc = { true },
     plugins = plugins + listOf(router)
 ), TestRib {
 

--- a/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/connectable/ConnectableTestNode.kt
+++ b/libraries/rib-base/src/test/java/com/badoo/ribs/core/helper/connectable/ConnectableTestNode.kt
@@ -11,6 +11,7 @@ import com.badoo.ribs.core.modality.AncestryInfo
 import com.badoo.ribs.core.modality.BuildParams
 import com.badoo.ribs.core.plugin.Plugin
 import com.badoo.ribs.routing.Routing
+import com.badoo.ribs.store.RetainedInstanceStore
 
 class ConnectableTestNode(
     buildParams: BuildParams<*>? = null,
@@ -20,6 +21,8 @@ class ConnectableTestNode(
 ) : Node<Nothing>(
     buildParams = buildParams ?: getDefaultBuildParams(parent),
     viewFactory = null,
+    retainedInstanceStore = RetainedInstanceStore,
+    isOnMainThreadFunc = { true },
     plugins = plugins
 ), ConnectableTestRib, Connectable<Input, Output> by connector {
 


### PR DESCRIPTION
**Description**:
Trigger `RIBs.ErrorHandler#handleNonFatalError` whenever a RIB node is interacted with off the main thread.
