### PR TITLE
Add negation for isChangingConfigurations in FragmentIntegrationPoint

### DIFF
--- a/libraries/rib-base/src/main/java/com/badoo/ribs/android/integrationpoint/FragmentIntegrationPoint.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/android/integrationpoint/FragmentIntegrationPoint.kt
@@ -52,7 +52,7 @@ open class FragmentIntegrationPoint(
      * checks whether the configuration change is occurring.
      */
     override val isFinishing: Boolean
-        get() = fragment.requireActivity().isChangingConfigurations
+        get() = !fragment.requireActivity().isChangingConfigurations
 
     override fun handleUpNavigation() {
         val activity = fragment.requireActivity()


### PR DESCRIPTION
In ActivityIntegrationPoint we use `NOT` of `activity.isChangingConfigurations` which is correct, since the activity is _not_ finishing i.e. is recreating when it is true.

However, in FragmentIntegrationPoint we use it without the negation, which means it thinks it is finishing when it is recreating and thinks it is not finishing when it is actually finishing.

This PR fixes it.
