### PR TITLE
Fix toDirectory() ext method to work property with lazy

### DIFF
--- a/libraries/rib-base-test/src/main/java/com/badoo/ribs/test/CustomisationExt.kt
+++ b/libraries/rib-base-test/src/main/java/com/badoo/ribs/test/CustomisationExt.kt
@@ -5,5 +5,5 @@ import com.badoo.ribs.core.customisation.RibCustomisationDirectory
 import com.badoo.ribs.core.customisation.RibCustomisationDirectoryImpl
 import com.bumble.appyx.utils.customisations.put
 
-fun RibCustomisation.toDirectory(): RibCustomisationDirectory =
+inline fun <reified T : RibCustomisation> T.toDirectory(): RibCustomisationDirectory =
     RibCustomisationDirectoryImpl().also { it.put { this } }


### PR DESCRIPTION
<!--
Thank you for contributing to RIBs. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

`toDirectory()` wasn't working properly with lazy customisations as it was always using `NodeCustomisation::class` as a key

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
