### PR TITLE
Fix backstack JDK 17 byte code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.parallel=true
 
-VERSION_NAME=0.40.3
+VERSION_NAME=0.40.4
 
 android.useAndroidX=true
 android.defaults.buildfeatures.buildconfig=true

--- a/libraries/rib-base/src/main/java/com/badoo/ribs/routing/source/backstack/BackStack.kt
+++ b/libraries/rib-base/src/main/java/com/badoo/ribs/routing/source/backstack/BackStack.kt
@@ -5,9 +5,9 @@ import android.os.Parcelable
 import com.badoo.ribs.core.modality.BuildParams
 import com.badoo.ribs.minimal.reactive.Cancellable
 import com.badoo.ribs.minimal.reactive.Source
+import com.badoo.ribs.minimal.reactive.map
 import com.badoo.ribs.minimal.state.Store
 import com.badoo.ribs.minimal.state.TimeCapsule
-import com.badoo.ribs.minimal.reactive.map
 import com.badoo.ribs.routing.Routing
 import com.badoo.ribs.routing.history.RoutingHistory
 import com.badoo.ribs.routing.history.RoutingHistoryElement
@@ -72,7 +72,9 @@ class BackStack<C : Parcelable> internal constructor(
     override fun baseLineState(fromRestored: Boolean): RoutingHistory<C> =
         timeCapsule.initialState()
 
-    private val store = object : Store<State<C>>(timeCapsule.initialState()) {
+    private val store = BackStackStore()
+
+    private inner class BackStackStore : Store<State<C>>(timeCapsule.initialState()) {
         init {
             timeCapsule.register(timeCapsuleKey) { state }
             initializeBackstack()
@@ -114,7 +116,10 @@ class BackStack<C : Parcelable> internal constructor(
                 )
             }
 
-        private fun routingWithCorrectId(element: RoutingHistoryElement<C>, index: Int): Routing<C> =
+        private fun routingWithCorrectId(
+            element: RoutingHistoryElement<C>,
+            index: Int
+        ): Routing<C> =
             element.routing.copy(
                 identifier = state.contentIdForPosition(
                     index,
@@ -122,7 +127,10 @@ class BackStack<C : Parcelable> internal constructor(
                 )
             )
 
-        private fun overlaysWithCorrectId(element: RoutingHistoryElement<C>, index: Int): List<Routing<C>> =
+        private fun overlaysWithCorrectId(
+            element: RoutingHistoryElement<C>,
+            index: Int
+        ): List<Routing<C>> =
             element.overlays.mapIndexed { overlayIndex, overlay ->
                 overlay.copy(
                     identifier = state.overlayIdForPosition(
@@ -144,7 +152,7 @@ class BackStack<C : Parcelable> internal constructor(
             }
 
     val activeConfiguration: C
-        get()= state.elements
+        get() = state.elements
             .last()
             .routing
             .configuration

--- a/samples/app/unsplash-client/src/test/java/com/badoo/ribs/example/root/RootInteractorAuthStateTest.kt
+++ b/samples/app/unsplash-client/src/test/java/com/badoo/ribs/example/root/RootInteractorAuthStateTest.kt
@@ -1,49 +1,67 @@
 package com.badoo.ribs.example.root
 
-// TODO: Uncomment once Mockito issues with BackStack are fixed.
-//  This blocked the update to AGP 8.2.2
-//@ExtendWith(RxSchedulerExtension::class)
-//class RootInteractorAuthStateTest {
-//
-//    private val backStack: BackStack<Configuration> = mock()
-//
-//    private val stateRelay = PublishRelay.create<AuthState>()
-//    private val authDataSource = mock<AuthDataSource>().apply {
-//        whenever(authUpdates).thenReturn(stateRelay)
-//    }
-//    private lateinit var interactor: RootInteractor
-//    private lateinit var interactorTestHelper: InteractorTestHelper<Nothing>
-//
-//    @BeforeEach
-//    fun setup() {
-//        interactor = RootInteractor(
-//            buildParams = emptyBuildParams(),
-//            backStack = backStack,
-//            authDataSource = authDataSource,
-//            networkErrors = PublishRelay.create()
-//        )
-//        interactorTestHelper = InteractorTestHelper(interactor)
-//    }
-//
-//    @ParameterizedTest
-//    @MethodSource("data")
-//    fun `an example test with some conditions should pass`(
-//        authState: AuthState,
-//        expectedConfiguration: Configuration
-//    ) {
-//        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.CREATED) {
-//            stateRelay.accept(authState)
-//
-//            verify(backStack).replace(expectedConfiguration)
-//        }
-//    }
-//
-//    companion object {
-//        @JvmStatic
-//        fun data(): Stream<Arguments> = Stream.of(
-//            Arguments.of(AuthState.Unauthenticated, Configuration.Content.LoggedOut),
-//            Arguments.of(AuthState.Anonymous, Configuration.Content.LoggedIn),
-//            Arguments.of(AuthState.Authenticated(""), Configuration.Content.LoggedIn)
-//        )
-//    }
-//}
+import androidx.lifecycle.Lifecycle
+import com.badoo.ribs.example.RxSchedulerExtension
+import com.badoo.ribs.example.auth.AuthDataSource
+import com.badoo.ribs.example.auth.AuthState
+import com.badoo.ribs.example.root.routing.RootRouter.Configuration
+import com.badoo.ribs.routing.source.backstack.BackStack
+import com.badoo.ribs.routing.source.backstack.operation.replace
+import com.badoo.ribs.test.InteractorTestHelper
+import com.badoo.ribs.test.emptyBuildParams
+import com.jakewharton.rxrelay2.PublishRelay
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.stream.Stream
+
+@ExtendWith(RxSchedulerExtension::class)
+class RootInteractorAuthStateTest {
+
+    private val backStack: BackStack<Configuration> = mock()
+
+    private val stateRelay = PublishRelay.create<AuthState>()
+    private val authDataSource = mock<AuthDataSource>().apply {
+        whenever(authUpdates).thenReturn(stateRelay)
+    }
+    private lateinit var interactor: RootInteractor
+    private lateinit var interactorTestHelper: InteractorTestHelper<Nothing>
+
+    @BeforeEach
+    fun setup() {
+        interactor = RootInteractor(
+            buildParams = emptyBuildParams(),
+            backStack = backStack,
+            authDataSource = authDataSource,
+            networkErrors = PublishRelay.create()
+        )
+        interactorTestHelper = InteractorTestHelper(interactor)
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    fun `an example test with some conditions should pass`(
+        authState: AuthState,
+        expectedConfiguration: Configuration
+    ) {
+        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.CREATED) {
+            stateRelay.accept(authState)
+
+            verify(backStack).replace(expectedConfiguration)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun data(): Stream<Arguments> = Stream.of(
+            Arguments.of(AuthState.Unauthenticated, Configuration.Content.LoggedOut),
+            Arguments.of(AuthState.Anonymous, Configuration.Content.LoggedIn),
+            Arguments.of(AuthState.Authenticated(""), Configuration.Content.LoggedIn)
+        )
+    }
+}

--- a/sandbox/src/test/java/com/badoo/ribs/sandbox/rib/switcher/SwitcherInteractorTest.kt
+++ b/sandbox/src/test/java/com/badoo/ribs/sandbox/rib/switcher/SwitcherInteractorTest.kt
@@ -1,54 +1,76 @@
 package com.badoo.ribs.sandbox.rib.switcher
 
-// TODO: Uncomment once Mockito issues with BackStack are fixed.
-//  This blocked the update to AGP 8.2.2
-//@RunWith(RobolectricTestRunner::class)
-//class SwitcherInteractorTest {
-//
-//    private val backStack: BackStack<Configuration> = mock()
-//    private val dialogToTestOverlay: DialogToTestOverlay = mock()
-//
-//    private val viewEventRelay = PublishRelay.create<Event>()
-//    private lateinit var interactor: SwitcherInteractor
-//    private lateinit var interactorTestHelper: InteractorTestHelper<SwitcherView>
-//
-//    @Before
-//    fun setup() {
-//        interactor = SwitcherInteractor(
-//            buildParams = emptyBuildParams(),
-//            backStack = backStack,
-//            dialogToTestOverlay = dialogToTestOverlay,
-//            transitions = Observable.just(SETTLED),
-//            transitionSettled = { true }
-//        )
-//
-//        interactorTestHelper = createInteractorTestHelper(interactor, viewEventRelay)
-//    }
-//
-//    @Test
-//    fun `router open overlay dialog when show overlay dialog clicked`(){
-//        interactorTestHelper.moveToStateAndCheck(STARTED) {
-//            viewEventRelay.accept(Event.ShowOverlayDialogClicked)
-//
-//            verify(backStack).pushOverlay(Overlay.Dialog)
-//        }
-//    }
-//
-//    @Test
-//    fun `router open blocker when show blocker clicked`(){
-//        interactorTestHelper.moveToStateAndCheck(STARTED) {
-//            viewEventRelay.accept(Event.ShowBlockerClicked)
-//
-//            verify(backStack).push(Content.Blocker)
-//        }
-//    }
-//
-//    @Test
-//    fun `skip view event when view not resumed`(){
-//        interactorTestHelper.moveToStateAndCheck(CREATED) {
-//            viewEventRelay.accept(Event.ShowBlockerClicked)
-//
-//            verify(backStack, never()).push(Content.Blocker)
-//        }
-//    }
-//}
+import androidx.lifecycle.Lifecycle.State.CREATED
+import androidx.lifecycle.Lifecycle.State.STARTED
+import com.badoo.common.ribs.rx2.createInteractorTestHelper
+import com.badoo.ribs.routing.router.Router.TransitionState.SETTLED
+import com.badoo.ribs.routing.source.backstack.BackStack
+import com.badoo.ribs.routing.source.backstack.operation.push
+import com.badoo.ribs.routing.source.backstack.operation.pushOverlay
+import com.badoo.ribs.sandbox.rib.switcher.SwitcherView.Event
+import com.badoo.ribs.sandbox.rib.switcher.dialog.DialogToTestOverlay
+import com.badoo.ribs.sandbox.rib.switcher.routing.SwitcherRouter.Configuration
+import com.badoo.ribs.sandbox.rib.switcher.routing.SwitcherRouter.Configuration.Content
+import com.badoo.ribs.sandbox.rib.switcher.routing.SwitcherRouter.Configuration.Overlay
+import com.badoo.ribs.test.InteractorTestHelper
+import com.badoo.ribs.test.emptyBuildParams
+import com.jakewharton.rxrelay2.PublishRelay
+import io.reactivex.Observable
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SwitcherInteractorTest {
+
+    private val backStack: BackStack<Configuration> = mock()
+    private val dialogToTestOverlay: DialogToTestOverlay = mock()
+
+    private val viewEventRelay = PublishRelay.create<Event>()
+    private lateinit var interactor: SwitcherInteractor
+    private lateinit var interactorTestHelper: InteractorTestHelper<SwitcherView>
+
+    @Before
+    fun setup() {
+        interactor = SwitcherInteractor(
+            buildParams = emptyBuildParams(),
+            backStack = backStack,
+            dialogToTestOverlay = dialogToTestOverlay,
+            transitions = Observable.just(SETTLED),
+            transitionSettled = { true }
+        )
+
+        interactorTestHelper = createInteractorTestHelper(interactor, viewEventRelay)
+    }
+
+    @Test
+    fun `router open overlay dialog when show overlay dialog clicked`() {
+        interactorTestHelper.moveToStateAndCheck(STARTED) {
+            viewEventRelay.accept(Event.ShowOverlayDialogClicked)
+
+            verify(backStack).pushOverlay(Overlay.Dialog)
+        }
+    }
+
+    @Test
+    fun `router open blocker when show blocker clicked`() {
+        interactorTestHelper.moveToStateAndCheck(STARTED) {
+            viewEventRelay.accept(Event.ShowBlockerClicked)
+
+            verify(backStack).push(Content.Blocker)
+        }
+    }
+
+    @Test
+    fun `skip view event when view not resumed`() {
+        interactorTestHelper.moveToStateAndCheck(CREATED) {
+            viewEventRelay.accept(Event.ShowBlockerClicked)
+
+            verify(backStack, never()).push(Content.Blocker)
+        }
+    }
+}


### PR DESCRIPTION
**Description**:
After attempting to use 0.40.3 I noticed Mockito was failing due to mock `BackStack` I then remembered that previously some tests were commented out that were also failing for this reason.

This issue only occurs when the library is compiled using JDK 17. By making a minor tweak to the source code we can eliminate the issue.

The error is as follows `Mismatch of count of formal and actual type arguments in constructor of com.badoo.ribs.routing.source.backstack.BackStack$store$1: 0 formal argument(s) 1 actual argument(s)`

The full error is below:

```
Underlying exception : org.mockito.exceptions.base.MockitoException: Could not modify all classes [interface com.badoo.ribs.routing.source.RoutingSource, interface com.badoo.ribs.core.plugin.Plugin, interface com.badoo.ribs.minimal.reactive.Source, class java.lang.Object, interface com.badoo.ribs.core.plugin.UpNavigationHandler, interface com.badoo.ribs.core.plugin.SavesInstanceState, interface com.badoo.ribs.core.plugin.SubtreeBackPressHandler, class com.badoo.ribs.routing.source.backstack.BackStack]
org.mockito.exceptions.base.MockitoException: 
Mockito cannot mock this class: class com.badoo.ribs.routing.source.backstack.BackStack.
Can not mock final classes with the following settings :
 - explicit serialization (e.g. withSettings().serializable())
 - extra interfaces (e.g. withSettings().extraInterfaces(...))

You are seeing this disclaimer because Mockito is configured to create inlined mocks.
You can learn about inline mocks and their limitations under item #39 of the Mockito class javadoc.

Underlying exception : org.mockito.exceptions.base.MockitoException: Could not modify all classes [interface com.badoo.ribs.routing.source.RoutingSource, interface com.badoo.ribs.core.plugin.Plugin, interface com.badoo.ribs.minimal.reactive.Source, class java.lang.Object, interface com.badoo.ribs.core.plugin.UpNavigationHandler, interface com.badoo.ribs.core.plugin.SavesInstanceState, interface com.badoo.ribs.core.plugin.SubtreeBackPressHandler, class com.badoo.ribs.routing.source.backstack.BackStack]
	at com.badoo.ribs.sandbox.rib.switcher.SwitcherInteractorTest.<init>(SwitcherInteractorTest.kt:92)
	at java.base@17.0.5/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base@17.0.5/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base@17.0.5/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base@17.0.5/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base@17.0.5/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at app//org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:250)
	at app//org.robolectric.RobolectricTestRunner$HelperTestRunner.createTest(RobolectricTestRunner.java:475)
	at app//org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:260)
	at app//org.junit.runners.BlockJUnit4ClassRunner$2.runReflectiveCall(BlockJUnit4ClassRunner.java:309)
	at app//org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at app//org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:306)
	at app//org.robolectric.internal.SandboxTestRunner$HelperTestRunner.methodBlock(SandboxTestRunner.java:375)
	at app//org.robolectric.RobolectricTestRunner$HelperTestRunner.methodBlock(RobolectricTestRunner.java:484)
	at app//org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$2(SandboxTestRunner.java:290)
	at app//org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:104)
	at java.base@17.0.5/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base@17.0.5/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base@17.0.5/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base@17.0.5/java.lang.Thread.run(Thread.java:833)
Caused by: org.mockito.exceptions.base.MockitoException: Could not modify all classes [interface com.badoo.ribs.routing.source.RoutingSource, interface com.badoo.ribs.core.plugin.Plugin, interface com.badoo.ribs.minimal.reactive.Source, class java.lang.Object, interface com.badoo.ribs.core.plugin.UpNavigationHandler, interface com.badoo.ribs.core.plugin.SavesInstanceState, interface com.badoo.ribs.core.plugin.SubtreeBackPressHandler, class com.badoo.ribs.routing.source.backstack.BackStack]
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:168)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:399)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:190)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:410)
	... 20 more
Caused by: java.lang.IllegalStateException: 
Byte Buddy could not instrument all classes within the mock's type hierarchy

This problem should never occur for javac-compiled classes. This problem has been observed for classes that are:
 - Compiled by older versions of scalac
 - Classes that are part of the Android distribution
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.triggerRetransformation(InlineBytecodeGenerator.java:285)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.mockClass(InlineBytecodeGenerator.java:218)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator.lambda$mockClass$0(TypeCachingBytecodeGenerator.java:78)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:168)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:399)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:190)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:410)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator.mockClass(TypeCachingBytecodeGenerator.java:75)
	at org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.createMockType(InlineDelegateByteBuddyMockMaker.java:414)
	at org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.doCreateMock(InlineDelegateByteBuddyMockMaker.java:373)
	at org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.createMock(InlineDelegateByteBuddyMockMaker.java:352)
	at org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker.createMock(InlineByteBuddyMockMaker.java:56)
	at org.mockito.internal.util.MockUtil.createMock(MockUtil.java:99)
	at org.mockito.internal.MockitoCore.mock(MockitoCore.java:84)
	at org.mockito.Mockito.mock(Mockito.java:2104)
	... 20 more
Caused by: java.lang.reflect.MalformedParameterizedTypeException: Mismatch of count of formal and actual type arguments in constructor of com.badoo.ribs.routing.source.backstack.BackStack$store$1: 0 formal argument(s) 1 actual argument(s)
	at java.base/sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl.validateConstructorArguments(ParameterizedTypeImpl.java:59)
	at java.base/sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl.<init>(ParameterizedTypeImpl.java:52)
	at java.base/sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl.make(ParameterizedTypeImpl.java:100)
	at java.base/sun.reflect.generics.factory.CoreReflectionFactory.makeParameterizedType(CoreReflectionFactory.java:105)
	at java.base/sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:140)
	at java.base/sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49)
	at java.base/sun.reflect.generics.repository.FieldRepository.computeGenericType(FieldRepository.java:90)
	at java.base/sun.reflect.generics.repository.FieldRepository.getGenericType(FieldRepository.java:82)
	at java.base/java.lang.reflect.Field.getGenericType(Field.java:276)
	at net.bytebuddy.description.type.TypeDescription$Generic$LazyProjection$ForLoadedFieldType.resolve(TypeDescription.java:6690)
	at net.bytebuddy.description.type.TypeDescription$Generic$LazyProjection.accept(TypeDescription.java:6302)
	at net.bytebuddy.description.field.FieldDescription$AbstractBase.asToken(FieldDescription.java:200)
	at net.bytebuddy.description.field.FieldDescription$AbstractBase.asToken(FieldDescription.java:123)
	at net.bytebuddy.description.field.FieldList$AbstractBase.asTokenList(FieldList.java:64)
	at net.bytebuddy.dynamic.scaffold.InstrumentedType$Factory$Default$1.represent(InstrumentedType.java:436)
	at net.bytebuddy.ByteBuddy.redefine(ByteBuddy.java:886)
	at net.bytebuddy.ByteBuddy.redefine(ByteBuddy.java:861)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.transform(InlineBytecodeGenerator.java:390)
	at java.instrument/java.lang.instrument.ClassFileTransformer.transform(ClassFileTransformer.java:244)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:541)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses0(Native Method)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses(InstrumentationImpl.java:169)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.triggerRetransformation(InlineBytecodeGenerator.java:281)
	... 34 more
```